### PR TITLE
Start work on Vineflower IR and IR tests

### DIFF
--- a/src/org/jetbrains/java/decompiler/main/collectors/ImportCollector.java
+++ b/src/org/jetbrains/java/decompiler/main/collectors/ImportCollector.java
@@ -63,6 +63,13 @@ public class ImportCollector {
     collectConflictingShortNames(root, new HashMap<>());
   }
 
+  // Unit testing use only!
+  public ImportCollector() {
+    currentPackageSlash = "pkg/";
+    currentPackagePoint = "pkg.";
+
+  }
+
   /**
    * Check whether the package-less name ClassName is shaded by variable in a context of
    * the decompiled class

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/LabelHelper.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/LabelHelper.java
@@ -46,6 +46,7 @@ public final class LabelHelper {
         case StatEdge.TYPE_CONTINUE:
           // If the continue is pointing somewhere that is not it's enclosed statement, move it to it's enclosed statement (and remove it from it's previous closure)
           if (edge.getDestination() != edge.closure) {
+            ValidationHelper.assertTrue(false, "Continue edge is not pointing to it's closure");
             edge.getDestination().addLabeledEdge(edge);
           }
           break;
@@ -280,8 +281,7 @@ public final class LabelHelper {
             for (Entry<Statement, List<StatEdge>> entr : mapEdges1.entrySet()) {
               if (mapEdges.containsKey(entr.getKey())) {
                 mapEdges.get(entr.getKey()).addAll(entr.getValue());
-              }
-              else {
+              } else {
                 mapEdges.put(entr.getKey(), entr.getValue());
               }
             }
@@ -410,9 +410,10 @@ public final class LabelHelper {
               }
             }
 
-            if (edge.closure instanceof DoStatement && stat instanceof IfStatement && edge.getDestination() instanceof DummyExitStatement) {
-              continue;
-            }
+            // TODO: is this needed anymore? It's never hit in the test suite
+//            if (edge.closure instanceof DoStatement && stat instanceof IfStatement && edge.getDestination() instanceof DummyExitStatement) {
+//              continue;
+//            }
 
             edge.explicit = false;
           }

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/StatEdge.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/StatEdge.java
@@ -122,7 +122,7 @@ public class StatEdge {
       case "FinExit":
         return TYPE_FINALLYEXIT;
       default:
-        throw new RuntimeException("Invalid edge type");
+        throw new RuntimeException("Invalid edge type: " + s);
     }
   }
 

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/StatEdge.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/StatEdge.java
@@ -91,6 +91,41 @@ public class StatEdge {
     return type;
   }
 
+  public String makeEdgeTypeString() {
+    switch (type) {
+      case TYPE_REGULAR:
+        return "Regular";
+      case TYPE_EXCEPTION:
+        return "Except";
+      case TYPE_BREAK:
+        return destination.type == Statement.StatementType.DUMMY_EXIT ? "BreakExit" : "Break";
+      case TYPE_CONTINUE:
+        return "Continue";
+      case TYPE_FINALLYEXIT:
+        return "FinExit";
+      default:
+        throw new RuntimeException("Invalid edge type");
+    }
+  }
+
+  public static int fromEdgeTypeString(String s) {
+    switch (s) {
+      case "Regular":
+        return TYPE_REGULAR;
+      case "Except":
+        return TYPE_EXCEPTION;
+      case "Break":
+      case "BreakExit":
+        return TYPE_BREAK;
+      case "Continue":
+        return TYPE_CONTINUE;
+      case "FinExit":
+        return TYPE_FINALLYEXIT;
+      default:
+        throw new RuntimeException("Invalid edge type");
+    }
+  }
+
   public void setType(int type) {
     this.type = type;
   }

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ArrayExprent.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ArrayExprent.java
@@ -3,6 +3,7 @@ package org.jetbrains.java.decompiler.modules.decompiler.exps;
 
 import org.jetbrains.java.decompiler.modules.decompiler.ExprProcessor;
 import org.jetbrains.java.decompiler.modules.decompiler.vars.CheckTypesResult;
+import org.jetbrains.java.decompiler.modules.serializer.ExprParser;
 import org.jetbrains.java.decompiler.struct.gen.VarType;
 import org.jetbrains.java.decompiler.util.InterpreterUtil;
 import org.jetbrains.java.decompiler.util.TextBuffer;
@@ -49,6 +50,21 @@ public class ArrayExprent extends Exprent {
     else {
       return exprType.decreaseArrayDim();
     }
+  }
+
+  @Override
+  protected void addToTapestry(StringBuilder sb) {
+    sb.append(hardType.toTapestryString());
+    sb.append(" ");
+    array.toTapestry(sb);
+    index.toTapestry(sb);
+  }
+
+  public static Exprent fromTapestry(ExprParser.Arg arg) {
+    VarType hardType = VarType.fromTapestryString(arg.getNextString());
+    Exprent array = arg.getNextExprent();
+    Exprent index = arg.getNextExprent();
+    return new ArrayExprent(array, index, hardType, null);
   }
 
   @Override

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/AssignmentExprent.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/AssignmentExprent.java
@@ -10,6 +10,7 @@ import org.jetbrains.java.decompiler.main.extern.IFernflowerPreferences;
 import org.jetbrains.java.decompiler.main.rels.MethodWrapper;
 import org.jetbrains.java.decompiler.modules.decompiler.ExprProcessor;
 import org.jetbrains.java.decompiler.modules.decompiler.vars.CheckTypesResult;
+import org.jetbrains.java.decompiler.modules.serializer.ExprParser;
 import org.jetbrains.java.decompiler.struct.StructField;
 import org.jetbrains.java.decompiler.struct.StructMethod;
 import org.jetbrains.java.decompiler.struct.gen.VarType;
@@ -301,6 +302,30 @@ public class AssignmentExprent extends Exprent {
     }
 
     buf.prepend("(" + ExprProcessor.getCastTypeName(left) + ")");
+  }
+
+  @Override
+  protected void addToTapestry(StringBuilder sb) {
+    if (condType != null) {
+      sb.append(condType.name());
+    }
+
+    sb.append(" ");
+    left.toTapestry(sb);
+    sb.append(" ");
+    right.toTapestry(sb);
+  }
+
+  public static Exprent fromTapestry(ExprParser.Arg arg) {
+    FunctionExprent.FunctionType condType = null;
+    if (arg.peekNext() == ExprParser.Type.STRING) {
+      condType = FunctionExprent.FunctionType.valueOf(arg.getNextString());
+    }
+
+    Exprent left = arg.getNextExprent();
+    Exprent right = arg.getNextExprent();
+
+    return new AssignmentExprent(left, right, condType, null);
   }
 
   @Override

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ConstExprent.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ConstExprent.java
@@ -541,7 +541,7 @@ public class ConstExprent extends Exprent {
     String rawVal = arg.getNextString();
     Object val = rawVal;
 
-    if (type.typeFamily == CodeConstants.TYPE_FAMILY_INTEGER) {
+    if (type.typeFamily == CodeConstants.TYPE_FAMILY_INTEGER || type == VarType.VARTYPE_BOOLEAN) {
       val = Integer.parseInt(rawVal);
     } else if (type == VarType.VARTYPE_LONG) {
       val = Long.parseLong(rawVal);
@@ -549,8 +549,6 @@ public class ConstExprent extends Exprent {
       val = Float.parseFloat(rawVal);
     } else if (type == VarType.VARTYPE_DOUBLE) {
       val = Double.parseDouble(rawVal);
-    } else if (type == VarType.VARTYPE_BOOLEAN) {
-      val = Boolean.parseBoolean(rawVal);
     } else if (type == VarType.VARTYPE_CHAR) {
       val = rawVal.charAt(0);
     } else if (type == VarType.VARTYPE_NULL) {

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ConstExprent.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ConstExprent.java
@@ -5,6 +5,7 @@ import org.jetbrains.java.decompiler.code.CodeConstants;
 import org.jetbrains.java.decompiler.main.DecompilerContext;
 import org.jetbrains.java.decompiler.main.extern.IFernflowerPreferences;
 import org.jetbrains.java.decompiler.modules.decompiler.ExprProcessor;
+import org.jetbrains.java.decompiler.modules.serializer.ExprParser;
 import org.jetbrains.java.decompiler.struct.gen.FieldDescriptor;
 import org.jetbrains.java.decompiler.struct.gen.VarType;
 import org.jetbrains.java.decompiler.struct.gen.generics.GenericType;
@@ -528,6 +529,35 @@ public class ConstExprent extends Exprent {
 
   public VarType getConstType() {
     return constType;
+  }
+
+  @Override
+  protected void addToTapestry(StringBuilder sb) {
+    sb.append(constType.toTapestryString()).append(" ").append(value);
+  }
+
+  public static Exprent fromTapestry(ExprParser.Arg arg) {
+    VarType type = VarType.fromTapestryString(arg.getNextString());
+    String rawVal = arg.getNextString();
+    Object val = rawVal;
+
+    if (type.typeFamily == CodeConstants.TYPE_FAMILY_INTEGER) {
+      val = Integer.parseInt(rawVal);
+    } else if (type == VarType.VARTYPE_LONG) {
+      val = Long.parseLong(rawVal);
+    } else if (type == VarType.VARTYPE_FLOAT) {
+      val = Float.parseFloat(rawVal);
+    } else if (type == VarType.VARTYPE_DOUBLE) {
+      val = Double.parseDouble(rawVal);
+    } else if (type == VarType.VARTYPE_BOOLEAN) {
+      val = Boolean.parseBoolean(rawVal);
+    } else if (type == VarType.VARTYPE_CHAR) {
+      val = rawVal.charAt(0);
+    } else if (type == VarType.VARTYPE_NULL) {
+      val = null;
+    }
+
+    return new ConstExprent(type, val, null);
   }
 
   public void setConstType(VarType constType) {

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ExitExprent.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ExitExprent.java
@@ -8,6 +8,7 @@ import org.jetbrains.java.decompiler.main.rels.MethodWrapper;
 import org.jetbrains.java.decompiler.modules.decompiler.ExprProcessor;
 import org.jetbrains.java.decompiler.modules.decompiler.ValidationHelper;
 import org.jetbrains.java.decompiler.modules.decompiler.vars.CheckTypesResult;
+import org.jetbrains.java.decompiler.modules.serializer.ExprParser;
 import org.jetbrains.java.decompiler.struct.attr.StructExceptionsAttribute;
 import org.jetbrains.java.decompiler.struct.attr.StructGeneralAttribute;
 import org.jetbrains.java.decompiler.struct.gen.MethodDescriptor;
@@ -119,6 +120,30 @@ public class ExitExprent extends Exprent {
 
       return buf.append(value.toJava(indent)).prepend("throw ");
     }
+  }
+
+  @Override
+  protected void addToTapestry(StringBuilder sb) {
+    sb.append(this.exitType.name());
+    sb.append(" ");
+    sb.append(this.retType.toTapestryString());
+
+    if (this.value != null) {
+      sb.append(" ");
+      this.value.toTapestry(sb);
+    }
+  }
+
+  public static Exprent fromTapestry(ExprParser.Arg arg) {
+    Type type = Type.valueOf(arg.getNextString());
+    VarType varType = VarType.fromTapestryString(arg.getNextString());
+
+    Exprent value = null;
+    if (arg.peekNext() == ExprParser.Type.EXPRENT) {
+      value = arg.getNextExprent();
+    }
+
+    return new ExitExprent(type, value, varType, null, null);
   }
 
   @Override

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/Exprent.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/Exprent.java
@@ -22,6 +22,7 @@ import org.jetbrains.java.decompiler.util.TextBuffer;
 
 import java.util.*;
 import java.util.Map.Entry;
+import java.util.function.Consumer;
 
 public abstract class Exprent implements IMatchable {
   public static final int MULTIPLE_USES = 1;
@@ -29,22 +30,32 @@ public abstract class Exprent implements IMatchable {
   public static final int BOTH_FLAGS = 3;
 
   public enum Type {
-    ANNOTATION,
-    ARRAY,
-    ASSERT,
-    ASSIGNMENT,
-    CONST,
-    EXIT,
-    FIELD,
-    FUNCTION,
-    IF,
-    INVOCATION,
-    MONITOR,
-    NEW,
-    SWITCH,
-    SWITCH_HEAD,
-    VAR,
-    YIELD,
+    ANNOTATION("Anno"),
+    ARRAY("Array"),
+    ASSERT("Assert"),
+    ASSIGNMENT("Assign"),
+    CONST("Const"),
+    EXIT("Return"),
+    FIELD("Field"),
+    FUNCTION("Func"),
+    IF("If"),
+    INVOCATION("Invoke"),
+    MONITOR("Monitor"),
+    NEW("New"),
+    SWITCH("SwitchExpr"),
+    SWITCH_HEAD("SwitchHead"),
+    VAR("Var"),
+    YIELD("Yield");
+
+    private final String prettyId;
+
+    Type(String prettyId) {
+      this.prettyId = prettyId;
+    }
+
+    public String getPrettyId() {
+      return prettyId;
+    }
   }
 
   protected static ThreadLocal<Map<String, VarType>> inferredLambdaTypes = ThreadLocal.withInitial(HashMap::new);
@@ -301,6 +312,22 @@ public abstract class Exprent implements IMatchable {
 
   public boolean allowNewlineAfterQualifier() {
     return true;
+  }
+
+  public final void toTapestry(StringBuilder sb) {
+    sb.append("[");
+    sb.append(type.prettyId);
+    StringBuilder child = new StringBuilder();
+    addToTapestry(child);
+    if (child.length() > 0) {
+      sb.append(" ");
+      sb.append(child);
+    }
+    sb.append("]");
+  }
+
+  protected void addToTapestry(StringBuilder sb) {
+
   }
 
   // *****************************************************************************

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FieldExprent.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FieldExprent.java
@@ -9,6 +9,7 @@ import org.jetbrains.java.decompiler.main.DecompilerContext;
 import org.jetbrains.java.decompiler.main.rels.MethodWrapper;
 import org.jetbrains.java.decompiler.modules.decompiler.ExprProcessor;
 import org.jetbrains.java.decompiler.modules.decompiler.vars.VarVersionPair;
+import org.jetbrains.java.decompiler.modules.serializer.ExprParser;
 import org.jetbrains.java.decompiler.struct.StructClass;
 import org.jetbrains.java.decompiler.struct.StructField;
 import org.jetbrains.java.decompiler.struct.attr.StructLocalVariableTableAttribute;
@@ -100,6 +101,34 @@ public class FieldExprent extends Exprent {
     }
 
     return getExprType();
+  }
+
+  @Override
+  protected void addToTapestry(StringBuilder sb) {
+    sb.append(name);
+    sb.append(" ");
+    sb.append(classname);
+    sb.append(" ");
+
+    sb.append(descriptor.descriptorString);
+
+    if (instance != null) {
+      sb.append(" ");
+      instance.toTapestry(sb);
+    }
+  }
+
+  public static Exprent fromTapestry(ExprParser.Arg arg) {
+    String name = arg.getNextString();
+    String classname = arg.getNextString();
+    String descString = arg.getNextString();
+
+    Exprent value = null;
+    if (arg.peekNext() == ExprParser.Type.EXPRENT) {
+      value = arg.getNextExprent();
+    }
+
+    return new FieldExprent(name, classname, value == null, value, FieldDescriptor.parseDescriptor(descString), null);
   }
 
   @Override

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FunctionExprent.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FunctionExprent.java
@@ -7,6 +7,7 @@ import org.jetbrains.java.decompiler.code.CodeConstants;
 import org.jetbrains.java.decompiler.main.DecompilerContext;
 import org.jetbrains.java.decompiler.modules.decompiler.ExprProcessor;
 import org.jetbrains.java.decompiler.modules.decompiler.vars.CheckTypesResult;
+import org.jetbrains.java.decompiler.modules.serializer.ExprParser;
 import org.jetbrains.java.decompiler.struct.gen.VarType;
 import org.jetbrains.java.decompiler.struct.gen.generics.GenericType;
 import org.jetbrains.java.decompiler.struct.match.MatchEngine;
@@ -408,6 +409,42 @@ public class FunctionExprent extends Exprent {
     }
 
     return result;
+  }
+
+  @Override
+  protected void addToTapestry(StringBuilder sb) {
+    sb.append(this.funcType.name());
+
+    if (implicitType != null) {
+      sb.append(" ");
+      sb.append(this.implicitType.toTapestryString());
+    }
+
+    List<Exprent> operands = this.getLstOperands();
+
+    for (Exprent operand : operands) {
+      sb.append(" ");
+      operand.toTapestry(sb);
+    }
+  }
+
+  public static Exprent fromTapestry(ExprParser.Arg arg) {
+    FunctionType type = FunctionType.valueOf(arg.getNextString());
+
+    VarType implicitType = null;
+    if (arg.peekNext() == ExprParser.Type.STRING) {
+      implicitType = VarType.fromTapestryString(arg.getNextString());
+    }
+
+    List<Exprent> exprents = new ArrayList<>();
+    while (arg.peekNext() == ExprParser.Type.EXPRENT) {
+      exprents.add(arg.getNextExprent());
+    }
+
+    FunctionExprent func =  new FunctionExprent(type, exprents, null);
+    func.setImplicitType(implicitType);
+
+    return func;
   }
 
   @Override

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/IfExprent.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/IfExprent.java
@@ -4,6 +4,7 @@
 package org.jetbrains.java.decompiler.modules.decompiler.exps;
 
 import org.jetbrains.java.decompiler.modules.decompiler.exps.FunctionExprent.FunctionType;
+import org.jetbrains.java.decompiler.modules.serializer.ExprParser;
 import org.jetbrains.java.decompiler.struct.gen.VarType;
 import org.jetbrains.java.decompiler.util.InterpreterUtil;
 import org.jetbrains.java.decompiler.util.collections.ListStack;
@@ -114,6 +115,15 @@ public class IfExprent extends Exprent {
   public IfExprent negateIf() {
     condition = new FunctionExprent(FunctionType.BOOL_NOT, condition, condition.bytecode);
     return this;
+  }
+
+  @Override
+  protected void addToTapestry(StringBuilder sb) {
+    condition.toTapestry(sb);
+  }
+
+  public static Exprent fromTapestry(ExprParser.Arg arg) {
+    return new IfExprent(arg.getNextExprent(), null);
   }
 
   public Exprent getCondition() {

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/VarExprent.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/VarExprent.java
@@ -14,6 +14,7 @@ import org.jetbrains.java.decompiler.modules.decompiler.vars.CheckTypesResult;
 import org.jetbrains.java.decompiler.modules.decompiler.vars.VarProcessor;
 import org.jetbrains.java.decompiler.modules.decompiler.vars.VarTypeProcessor.FinalType;
 import org.jetbrains.java.decompiler.modules.decompiler.vars.VarVersionPair;
+import org.jetbrains.java.decompiler.modules.serializer.ExprParser;
 import org.jetbrains.java.decompiler.struct.StructClass;
 import org.jetbrains.java.decompiler.struct.attr.StructGeneralAttribute;
 import org.jetbrains.java.decompiler.struct.attr.StructLocalVariableTableAttribute;
@@ -362,6 +363,34 @@ public class VarExprent extends Exprent {
     }
 
     return pair.version == 0 ? "var" + pair.var : "var" + pair.var + "_" + version;
+  }
+
+  @Override
+  protected void addToTapestry(StringBuilder sb) {
+    VarVersionPair vvp = getVarVersionPair();
+
+    sb.append(this.varType.toTapestryString());
+    sb.append(" ");
+
+    sb.append(vvp.var);
+    if (vvp.version != 0) {
+      sb.append(" ").append(vvp.version);
+    }
+  }
+
+  public static Exprent fromTapestry(ExprParser.Arg arg) {
+    VarType type = VarType.fromTapestryString(arg.getNextString());
+    int var = Integer.parseInt(arg.getNextString());
+
+    int ver = 0;
+    if (arg.peekNext() == ExprParser.Type.STRING) {
+      ver = Integer.parseInt(arg.getNextString());
+    }
+
+    VarExprent varEx = new VarExprent(var, type, null, null);
+    varEx.setVersion(ver);
+
+    return varEx;
   }
 
   public void setBoundType(VarType boundType) {

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/BasicBlockStatement.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/BasicBlockStatement.java
@@ -30,6 +30,13 @@ public final class BasicBlockStatement extends Statement {
   // constructors
   // *****************************************************************************
 
+  public BasicBlockStatement(int id) {
+    super(StatementType.BASIC_BLOCK, id);
+
+    block = new BasicBlock(id);
+    exprents = new ArrayList<>();
+  }
+
   public BasicBlockStatement(BasicBlock block) {
 
     super(StatementType.BASIC_BLOCK, block.id);

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/CatchAllStatement.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/CatchAllStatement.java
@@ -34,6 +34,10 @@ public final class CatchAllStatement extends Statement {
     super(StatementType.CATCH_ALL);
   }
 
+  public CatchAllStatement(int id) {
+    super(StatementType.CATCH_ALL, id);
+  }
+
   private CatchAllStatement(Statement head, Statement handler) {
 
     this();

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/CatchStatement.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/CatchStatement.java
@@ -33,6 +33,10 @@ public final class CatchStatement extends Statement {
     super(StatementType.TRY_CATCH);
   }
 
+  public CatchStatement(int id) {
+    super(StatementType.TRY_CATCH, id);
+  }
+
   private CatchStatement(Statement head, Statement next, Set<Statement> setHandlers) {
     this();
 

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/DoStatement.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/DoStatement.java
@@ -11,6 +11,7 @@ import org.jetbrains.java.decompiler.util.TextBuffer;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Consumer;
 
 // Loop statement
 public final class DoStatement extends Statement {
@@ -30,6 +31,15 @@ public final class DoStatement extends Statement {
 
   private DoStatement() {
     super(StatementType.DO);
+    looptype = Type.INFINITE;
+
+    initExprent.add(null);
+    conditionExprent.add(null);
+    incExprent.add(null);
+  }
+
+  public DoStatement(int id) {
+    super(StatementType.DO, id);
     looptype = Type.INFINITE;
 
     initExprent.add(null);
@@ -209,6 +219,42 @@ public final class DoStatement extends Statement {
     }
 
     return vars;
+  }
+
+  @Override
+  public void addToTapestry(Consumer<String> annotator) {
+    if (looptype == Type.FOR_EACH) {
+      annotator.accept("ForEach");
+    } else if (looptype == Type.FOR) {
+      annotator.accept("For");
+    } else if (looptype == Type.WHILE) {
+      annotator.accept("While");
+    } else if (looptype == Type.DO_WHILE) {
+      annotator.accept("DoWhile");
+    } else if (looptype == Type.INFINITE) {
+      annotator.accept("Do");
+    }
+  }
+
+  @Override
+  public void readFromTapestry(String annotation) {
+    switch (annotation) {
+      case "ForEach":
+        looptype = Type.FOR_EACH;
+        break;
+      case "For":
+        looptype = Type.FOR;
+        break;
+      case "While":
+        looptype = Type.WHILE;
+        break;
+      case "DoWhile":
+        looptype = Type.DO_WHILE;
+        break;
+      case "Do":
+        looptype = Type.INFINITE;
+        break;
+    }
   }
 
   @Override

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/DummyExitStatement.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/DummyExitStatement.java
@@ -6,6 +6,10 @@ import java.util.BitSet;
 public final class DummyExitStatement extends Statement {
   public BitSet bytecode = null;  // offsets of bytecode instructions mapped to dummy exit
 
+  public DummyExitStatement(int id) {
+    super(StatementType.DUMMY_EXIT, id);
+  }
+
   public DummyExitStatement() {
     super(StatementType.DUMMY_EXIT);
   }

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/IfStatement.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/IfStatement.java
@@ -18,6 +18,7 @@ import org.jetbrains.java.decompiler.util.TextUtil;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Consumer;
 
 
 public final class IfStatement extends Statement {
@@ -50,6 +51,12 @@ public final class IfStatement extends Statement {
 
   private IfStatement() {
     super(StatementType.IF);
+
+    headexprent.add(null);
+  }
+
+  public IfStatement(int id) {
+    super(StatementType.IF, id);
 
     headexprent.add(null);
   }
@@ -424,6 +431,48 @@ public final class IfStatement extends Statement {
 
   public void setHasPPMM(boolean hasPPMM) {
     this.hasPPMM = hasPPMM;
+  }
+
+  @Override
+  public void addToTapestry(Consumer<String> annotator) {
+    if (iftype == IFTYPE_IF) {
+      annotator.accept("If");
+    } else if (iftype == IFTYPE_IFELSE) {
+      annotator.accept("IfElse");
+    }
+
+    if (negated) {
+      annotator.accept("Neg");
+    }
+
+    if (hasPPMM) {
+      annotator.accept("PPMM");
+    }
+
+    if (patternMatched) {
+      annotator.accept("Matched");
+    }
+  }
+
+  @Override
+  public void readFromTapestry(String annotation) {
+    switch (annotation) {
+      case "If":
+        iftype = IFTYPE_IF;
+        break;
+      case "IfElse":
+        iftype = IFTYPE_IFELSE;
+        break;
+      case "Neg":
+        negated = true;
+        break;
+      case "PPMM":
+        hasPPMM = true;
+        break;
+      case "Matched":
+        patternMatched = true;
+        break;
+    }
   }
 
   @Override

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/RootStatement.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/RootStatement.java
@@ -11,11 +11,16 @@ import java.util.LinkedHashSet;
 import java.util.Set;
 
 public final class RootStatement extends Statement {
-  private final DummyExitStatement dummyExit;
+  private DummyExitStatement dummyExit;
   public final StructMethod mt;
   public Set<String> commentLines = null;
   public boolean addErrorComment = false;
   private final ContentFlags flags = new ContentFlags();
+
+  public RootStatement(int id) {
+    super(StatementType.ROOT, id);
+    this.mt = null;
+  }
 
   public RootStatement(Statement head, DummyExitStatement dummyExit, StructMethod mt) {
     super(StatementType.ROOT);
@@ -90,6 +95,10 @@ public final class RootStatement extends Statement {
     } else if (stat instanceof SwitchStatement) {
       this.flags.hasSwitch = true;
     }
+  }
+
+  public void setDummyExit(DummyExitStatement dummyExit) {
+    this.dummyExit = dummyExit;
   }
 
   public boolean hasTryCatch() {

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/SequenceStatement.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/SequenceStatement.java
@@ -21,6 +21,10 @@ public final class SequenceStatement extends Statement {
     super(StatementType.SEQUENCE);
   }
 
+  public SequenceStatement(int id) {
+    super(StatementType.SEQUENCE, id);
+  }
+
   public SequenceStatement(Statement... stats) {
     this(Arrays.asList(stats));
   }

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/Statement.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/Statement.java
@@ -23,6 +23,7 @@ import org.jetbrains.java.decompiler.util.collections.VBStyleCollection;
 
 import java.util.*;
 import java.util.Map.Entry;
+import java.util.function.Consumer;
 
 public abstract class Statement implements IMatchable {
   public enum StatementType {
@@ -35,6 +36,10 @@ public abstract class Statement implements IMatchable {
 
     StatementType(String prettyId) {
       this.prettyId = prettyId;
+    }
+
+    public String getPrettyId() {
+      return prettyId;
     }
   }
   // All edge types
@@ -853,6 +858,14 @@ public abstract class Statement implements IMatchable {
     }
 
     throw new IllegalStateException("No successor exists for " + this);
+  }
+
+  public void addToTapestry(Consumer<String> annotator) {
+
+  }
+
+  public void readFromTapestry(String annotation) {
+
   }
 
   public List<StatEdge> getAllPredecessorEdges() {

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/SwitchStatement.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/SwitchStatement.java
@@ -515,6 +515,10 @@ public final class SwitchStatement extends Statement {
     return defaultEdge;
   }
 
+  public void setDefaultEdge(StatEdge defaultEdge) {
+    this.defaultEdge = defaultEdge;
+  }
+
   public List<List<Exprent>> getCaseValues() {
     return caseValues;
   }

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/SynchronizedStatement.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/SynchronizedStatement.java
@@ -29,6 +29,12 @@ public final class SynchronizedStatement extends Statement {
     headexprent.add(null);
   }
 
+  public SynchronizedStatement(int id) {
+    super(StatementType.SYNCHRONIZED, id);
+
+    headexprent.add(null);
+  }
+
   public SynchronizedStatement(Statement head, Statement body, Statement exc) {
 
     this();

--- a/src/org/jetbrains/java/decompiler/modules/serializer/ExprParser.java
+++ b/src/org/jetbrains/java/decompiler/modules/serializer/ExprParser.java
@@ -1,0 +1,153 @@
+package org.jetbrains.java.decompiler.modules.serializer;
+
+import org.jetbrains.java.decompiler.modules.decompiler.exps.*;
+import org.jetbrains.java.decompiler.util.Pair;
+
+import java.util.*;
+
+public final class ExprParser {
+  private static final Map<String, TapestryDeserializer> DESERIALIZERS = new HashMap<>();
+  static {
+    DESERIALIZERS.put(Exprent.Type.CONST.getPrettyId(), ConstExprent::fromTapestry);
+    DESERIALIZERS.put(Exprent.Type.ASSIGNMENT.getPrettyId(), AssignmentExprent::fromTapestry);
+    DESERIALIZERS.put(Exprent.Type.ARRAY.getPrettyId(), ArrayExprent::fromTapestry);
+    DESERIALIZERS.put(Exprent.Type.INVOCATION.getPrettyId(), InvocationExprent::fromTapestry);
+    DESERIALIZERS.put(Exprent.Type.IF.getPrettyId(), IfExprent::fromTapestry);
+    DESERIALIZERS.put(Exprent.Type.FUNCTION.getPrettyId(), FunctionExprent::fromTapestry);
+    DESERIALIZERS.put(Exprent.Type.EXIT.getPrettyId(), ExitExprent::fromTapestry);
+    DESERIALIZERS.put(Exprent.Type.FIELD.getPrettyId(), FieldExprent::fromTapestry);
+    DESERIALIZERS.put(Exprent.Type.VAR.getPrettyId(), VarExprent::fromTapestry);
+  }
+
+
+  public static Exprent parse(String expr) {
+    String[] s = expr
+      .replaceAll("\\]", "] ")
+      .replaceAll("\\s+", " ")
+      .split(" ");
+
+    Block block = parseArguments(s[0].substring(1), s, 1).a;
+
+    return DESERIALIZERS.get(block.name).deserialize(block);
+  }
+
+  // return: [arg, end]
+  private static Pair<Block, Integer> parseArguments(String name, String[] args, int start) {
+    List<Arg> arguments = new ArrayList<>();
+    int length = args.length;
+
+    for (int i = start; i < length; i++) {
+      String arg = args[i];
+      if (arg.startsWith("[")) {
+        Pair<Block, Integer> block = parseArguments(arg.substring(1), args, i + 1);
+        i = block.b;
+        arguments.add(block.a);
+      } else {
+        arguments.add(new Literal(arg.replace("]", "")));
+      }
+
+      if (arg.endsWith("]")) {
+        arguments.removeIf(a -> a instanceof Literal && ((Literal) a).value.isEmpty());
+        return Pair.of(new Block(name, arguments), i);
+      }
+    }
+
+    return Pair.of(new Block(name, arguments), args.length - 1);
+  }
+
+  public static abstract class Arg {
+    public abstract String getNextString();
+    public abstract Exprent getNextExprent();
+
+    public abstract Type peekNext();
+  }
+
+  private static final class Literal extends Arg {
+    private final String value;
+
+    private Literal(String value) {
+      this.value = value;
+    }
+
+    @Override
+    public String toString() {
+      return "L{" + value + "}";
+    }
+
+    @Override
+    public String getNextString() {
+      throw new IllegalStateException("Cannot call this from a literal");
+    }
+
+    @Override
+    public Exprent getNextExprent() {
+      throw new IllegalStateException("Cannot call this from a literal");
+    }
+
+    @Override
+    public Type peekNext() {
+      throw new IllegalStateException("Cannot call this from a literal");
+    }
+  }
+
+  private static final class Block extends Arg {
+    private final String name;
+
+    private final List<Arg> args;
+
+    private int pointer = 0;
+
+    private Block(String name, List<Arg> args) {
+      this.name = name;
+      this.args = args;
+    }
+
+    @Override
+    public String toString() {
+      return "B{(" + name + ") " + args.toString() + "}";
+    }
+
+    @Override
+    public String getNextString() {
+      Arg arg = args.get(pointer++);
+
+      if (arg instanceof Literal) {
+        return ((Literal) arg).value;
+      } else {
+        throw new IllegalStateException("Wanted string, found expression instead");
+      }
+    }
+
+    @Override
+    public Exprent getNextExprent() {
+      Arg arg = args.get(pointer++);
+
+      if (arg instanceof Block) {
+        return DESERIALIZERS.get(((Block) arg).name).deserialize(arg);
+      } else {
+        throw new IllegalStateException("Wanted expression, found string instead");
+      }
+    }
+
+    @Override
+    public Type peekNext() {
+      if (pointer >= args.size()) {
+        return Type.END;
+      }
+
+      Arg arg = args.get(pointer);
+
+      if (arg instanceof Literal) {
+        return Type.STRING;
+      } else {
+        return Type.EXPRENT;
+      }
+    }
+  }
+
+  public enum Type {
+    STRING,
+    EXPRENT,
+    END
+  }
+}

--- a/src/org/jetbrains/java/decompiler/modules/serializer/TapestryDeserializer.java
+++ b/src/org/jetbrains/java/decompiler/modules/serializer/TapestryDeserializer.java
@@ -1,0 +1,8 @@
+package org.jetbrains.java.decompiler.modules.serializer;
+
+import org.jetbrains.java.decompiler.modules.decompiler.exps.Exprent;
+
+@FunctionalInterface
+public interface TapestryDeserializer {
+  Exprent deserialize(ExprParser.Arg arg);
+}

--- a/src/org/jetbrains/java/decompiler/modules/serializer/TapestryReader.java
+++ b/src/org/jetbrains/java/decompiler/modules/serializer/TapestryReader.java
@@ -1,0 +1,362 @@
+package org.jetbrains.java.decompiler.modules.serializer;
+
+import org.jetbrains.java.decompiler.modules.decompiler.StatEdge;
+import org.jetbrains.java.decompiler.modules.decompiler.exps.Exprent;
+import org.jetbrains.java.decompiler.modules.decompiler.exps.VarExprent;
+import org.jetbrains.java.decompiler.modules.decompiler.stats.*;
+import org.jetbrains.java.decompiler.util.DotExporter;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+public final class TapestryReader {
+  private static final Map<String, Statement.StatementType> TYPES = Arrays.stream(Statement.StatementType.values())
+    .collect(Collectors.toMap(Statement.StatementType::getPrettyId, t -> t));
+  public static RootStatement readTapestry(String data) {
+    String[] split = data.split("\n");
+
+    List<StatRec> statRecs = new ArrayList<>();
+    Map<Integer, Statement> stats = new HashMap<>();
+    List<EdgeRec> edges = new ArrayList<>();
+
+    Map<Integer, List<Exprent>> exprMaps = new HashMap<>();
+    for (String s : split) {
+      s = s.replaceAll("\\s+", " ");
+
+      String[] components = s.split(" ");
+
+      if (components[1].equals("->")) {
+        // Edge
+        edges.add(readEdge(components));
+      } else if (components[1].equals("<")) {
+        // Expr
+
+        int id = Integer.parseInt(components[0]);
+
+        exprMaps.computeIfAbsent(id, k -> new ArrayList<>())
+          .add(readExpr(components));
+
+      } else {
+        // Statement
+        StatRec stat = readStatement(components);
+        statRecs.add(stat);
+      }
+    }
+
+    for (StatRec v : statRecs) {
+      stats.put(v.id, makeFull(v));
+    }
+
+    for (StatRec rec : statRecs) {
+      Statement thisSt = stats.get(rec.id);
+
+      if (rec.parentId != -1) {
+        Statement parSt = stats.get(rec.parentId);
+
+        thisSt.setParent(parSt);
+        parSt.getStats().putWithKey(thisSt, thisSt.id);
+      }
+
+      if (rec.firstId != -1) {
+        Statement firstSt = stats.get(rec.firstId);
+
+        thisSt.setFirst(firstSt);
+        thisSt.getStats().putWithKey(firstSt, firstSt.id);
+      }
+
+      for (String d : rec.data) {
+        thisSt.readFromTapestry(d);
+      }
+    }
+
+    for (EdgeRec edge : edges) {
+      Statement src = stats.get(edge.sourceId);
+      Statement dest = stats.get(edge.destId);
+
+      StatEdge statEdge = new StatEdge(edge.edgeType, src, dest);
+      statEdge.labeled = edge.labeled;
+      statEdge.explicit = edge.explicit;
+      statEdge.canInline = edge.canInline;
+      statEdge.phantomContinue = edge.phantomContinue;
+
+      if (edge.closureId != -1) {
+        statEdge.closure = stats.get(edge.closureId);
+      }
+
+      if (edge.ifId != -1) {
+        ((IfStatement)stats.get(edge.ifId)).setIfEdge(statEdge);
+        ((IfStatement)stats.get(edge.ifId)).setIfstat(statEdge.getDestination());
+      }
+
+      if (edge.elseId != -1) {
+        ((IfStatement)stats.get(edge.elseId)).setIfEdge(statEdge);
+        ((IfStatement)stats.get(edge.ifId)).setElsestat(statEdge.getDestination());
+      }
+
+      if (edge.defaultId != -1) {
+        ((SwitchStatement)stats.get(edge.defaultId)).setDefaultEdge(statEdge);
+      }
+
+      src.addSuccessor(statEdge);
+    }
+
+    RootStatement root = null;
+    DummyExitStatement dummyExitStatement = null;
+
+    for (Statement v : stats.values()) {
+      // Find key statements
+      if (v instanceof RootStatement) {
+        root = (RootStatement) v;
+      }
+
+      if (v instanceof DummyExitStatement) {
+        dummyExitStatement = (DummyExitStatement) v;
+      }
+
+      // Set exprs
+      List<Exprent> exprs = exprMaps.get(v.id);
+      if (exprs != null) {
+        if (v instanceof BasicBlockStatement) {
+          v.getExprents().addAll(exprs);
+        } else if (v instanceof IfStatement) {
+          ((IfStatement)v).getHeadexprentList().set(0, exprs.get(0));
+        } else if (v instanceof DoStatement) {
+          DoStatement loop = (DoStatement) v;
+
+          if (exprs.size() == 1) {
+            loop.setConditionExprent(exprs.get(0));
+          } else if (exprs.size() == 2) {
+            loop.setInitExprent(exprs.get(0));
+            loop.setIncExprent(exprs.get(1));
+          } else if (exprs.size() == 3) {
+            loop.setInitExprent(exprs.get(0));
+            loop.setConditionExprent(exprs.get(1));
+            loop.setIncExprent(exprs.get(2));
+          }
+        }
+      }
+    }
+
+    root.setDummyExit(dummyExitStatement);
+    DotExporter.toDotFile(root, "tapestry" + ++i);
+
+    return root;
+  }
+  private static int i = 0;
+
+  private static Statement makeFull(StatRec rec) {
+    switch (rec.type) {
+      case ROOT:
+        return new RootStatement(rec.id);
+      case SEQUENCE:
+        return new SequenceStatement(rec.id);
+      case DUMMY_EXIT:
+        return new DummyExitStatement(rec.id);
+      case GENERAL:
+        throw new IllegalStateException("Can't deserialize general statements yet");
+      case BASIC_BLOCK:
+        return new BasicBlockStatement(rec.id);
+      case IF:
+        return new IfStatement(rec.id);
+      case DO:
+        return new DoStatement(rec.id);
+      case SWITCH:
+        throw new IllegalStateException("Can't deserialize switch statements yet");
+      case SYNCHRONIZED:
+        return new SynchronizedStatement(rec.id);
+      case TRY_CATCH:
+        return new CatchStatement(rec.id);
+      case CATCH_ALL:
+        return new CatchAllStatement(rec.id);
+      default:
+        throw new RuntimeException("Unknown type: " + rec.type);
+    }
+  }
+
+  private static StatRec readStatement(String[] components) {
+    int id = Integer.parseInt(components[0]);
+    Statement.StatementType type = TYPES.get(components[1]);
+
+    int parentId = -1;
+    int firstId = -1;
+    List<String> data = new ArrayList<>();
+    for (int i = 2; i < components.length; i++) {
+      String component = components[i];
+      if (component.startsWith("P:")) {
+        parentId = Integer.parseInt(component.substring(2));
+      } else if (component.startsWith("F:")) {
+        firstId = Integer.parseInt(component.substring(2));
+      } else if (component.startsWith("D:")) {
+        data.add(component.substring(2));
+      }
+    }
+
+    return new StatRec(id, type, parentId, firstId, data);
+  }
+
+  private static EdgeRec readEdge(String[] components) {
+    int sourceId = Integer.parseInt(components[0]);
+    // components[1] is the arrow
+    int destId = Integer.parseInt(components[2]);
+    int type = StatEdge.fromEdgeTypeString(components[3]);
+
+    EdgeRecBuilder builder = new EdgeRecBuilder();
+    for (int i = 4; i < components.length; i++) {
+      String component = components[i];
+      if (component.startsWith("C:")) {
+        builder.setClosureId(Integer.parseInt(component.substring(2)));
+      } else if (component.startsWith("If:")) {
+        builder.setIfId(Integer.parseInt(component.substring(3)));
+      } else if (component.startsWith("IfE:")) {
+        builder.setElseId(Integer.parseInt(component.substring(4)));
+      } else if (component.startsWith("D:")) {
+        builder.setDefaultId(Integer.parseInt(component.substring(2)));
+      } else if (component.equals("L")) {
+        builder.setLabeled(true);
+      } else if (component.equals("E")) {
+        builder.setExplicit(true);
+      } else if (component.equals("I")) {
+        builder.setCanInline(false);
+      } else if (component.equals("P")) {
+        builder.setPhantomContinue(true);
+      }
+    }
+
+    return builder
+      .setEdgeType(type)
+      .setSourceId(sourceId)
+      .setDestId(destId)
+      .createEdgeRec();
+  }
+
+  private static Exprent readExpr(String[] components) {
+    StringBuilder content = new StringBuilder();
+    for (int i = 2; i < components.length; i++) {
+      content.append(components[i]);
+
+      if (i != components.length - 1) {
+        content.append(" ");
+      }
+    }
+
+    return ExprParser.parse(content.toString());
+  }
+
+  private static class StatRec {
+    private final int id;
+    private final Statement.StatementType type;
+    private final int parentId;
+    private final int firstId;
+    private final List<String> data;
+
+    private StatRec(int id, Statement.StatementType type, int parentId, int firstId, List<String> data) {
+      this.id = id;
+      this.type = type;
+      this.parentId = parentId;
+      this.firstId = firstId;
+      this.data = data;
+    }
+  }
+
+  static class EdgeRec {
+    private final int edgeType;
+    private final int sourceId;
+    private final int destId;
+    private final int closureId;
+
+    private final boolean labeled;
+    private final boolean explicit;
+    private final boolean canInline;
+    private final boolean phantomContinue;
+    private final int ifId;
+    private final int elseId;
+    private final int defaultId;
+
+    EdgeRec(int edgeType, int sourceId, int destId, int closureId, boolean labeled, boolean explicit, boolean canInline, boolean phantomContinue, int ifId, int elseId, int defaultId) {
+      this.edgeType = edgeType;
+      this.sourceId = sourceId;
+      this.destId = destId;
+      this.closureId = closureId;
+      this.labeled = labeled;
+      this.explicit = explicit;
+      this.canInline = canInline;
+      this.phantomContinue = phantomContinue;
+      this.ifId = ifId;
+      this.elseId = elseId;
+      this.defaultId = defaultId;
+    }
+  }
+
+  public static class EdgeRecBuilder {
+      private int edgeType;
+      private int sourceId;
+      private int destId;
+      private int closureId = -1;
+      private boolean labeled;
+      private boolean explicit;
+      private boolean canInline = true;
+      private boolean phantomContinue;
+      private int ifId = -1;
+      private int elseId = -1;
+      private int defaultId = -1;
+
+      public EdgeRecBuilder setEdgeType(int edgeType) {
+          this.edgeType = edgeType;
+          return this;
+      }
+
+      public EdgeRecBuilder setSourceId(int sourceId) {
+          this.sourceId = sourceId;
+          return this;
+      }
+
+      public EdgeRecBuilder setDestId(int destId) {
+          this.destId = destId;
+          return this;
+      }
+
+      public EdgeRecBuilder setClosureId(int closureId) {
+          this.closureId = closureId;
+          return this;
+      }
+
+      public EdgeRecBuilder setLabeled(boolean labeled) {
+          this.labeled = labeled;
+          return this;
+      }
+
+      public EdgeRecBuilder setExplicit(boolean explicit) {
+          this.explicit = explicit;
+          return this;
+      }
+
+      public EdgeRecBuilder setCanInline(boolean canInline) {
+          this.canInline = canInline;
+          return this;
+      }
+
+      public EdgeRecBuilder setPhantomContinue(boolean phantomContinue) {
+          this.phantomContinue = phantomContinue;
+          return this;
+      }
+
+      public EdgeRecBuilder setIfId(int ifId) {
+          this.ifId = ifId;
+          return this;
+      }
+
+      public EdgeRecBuilder setElseId(int elseId) {
+          this.elseId = elseId;
+          return this;
+      }
+
+      public EdgeRecBuilder setDefaultId(int defaultId) {
+          this.defaultId = defaultId;
+          return this;
+      }
+
+      public EdgeRec createEdgeRec() {
+          return new EdgeRec(edgeType, sourceId, destId, closureId, labeled, explicit, canInline, phantomContinue, ifId, elseId, defaultId);
+      }
+  }
+}

--- a/src/org/jetbrains/java/decompiler/modules/serializer/TapestryWriter.java
+++ b/src/org/jetbrains/java/decompiler/modules/serializer/TapestryWriter.java
@@ -1,0 +1,279 @@
+package org.jetbrains.java.decompiler.modules.serializer;
+
+import org.jetbrains.java.decompiler.code.cfg.BasicBlock;
+import org.jetbrains.java.decompiler.modules.decompiler.StatEdge;
+import org.jetbrains.java.decompiler.modules.decompiler.exps.Exprent;
+import org.jetbrains.java.decompiler.modules.decompiler.stats.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+
+public final class TapestryWriter {
+  // [] are replaced with the actual value
+  // () are inlined comments
+  // id [Type] P:[parent] F:[first] ...D:[Extra data]
+  // id -> [dest] [EdgeType] C:[closure] L (flag for labeled, true if present) E (flag for explicit) I (canInline, inverted) P (phantomContinue)
+
+
+  // Serializes the statement graph into a string delimited by newline (\n) characters.
+  public static String serialize(RootStatement root) {
+    StringBuilder sb = new StringBuilder();
+    List<Statement> stats = new ArrayList<>();
+    stats.add(root);
+    findAllStats(stats, root);
+
+    int maxId = stats.stream().map(s -> s.id).max(Integer::compare).orElse(0);
+    // Make sure all spaces are aligned properly by padding
+    int maxSpaces = charsInId(maxId);
+
+    int maxNameId = 0;
+    for (Statement stat : stats) {
+      int nameId = stat.type.getPrettyId().length();
+      if (nameId > maxNameId) {
+        maxNameId = nameId;
+      }
+    }
+
+    int maxEdgeId = 0;
+    for (Statement stat : stats) {
+      for (StatEdge edge : stat.getAllSuccessorEdges()) {
+        int edgeId = edge.makeEdgeTypeString().length();
+        if (edgeId > maxEdgeId) {
+          maxEdgeId = edgeId;
+
+          // 9 is the length of "BreakExit", the longest type string
+          if (maxEdgeId == 9) {
+            break;
+          }
+        }
+      }
+
+      if (maxEdgeId == 9) {
+        break;
+      }
+    }
+
+    for (Statement st : stats) {
+      int spaces = charsInId(st.id) - 1;
+
+      StringBuilder eb = new StringBuilder();
+
+      eb.append(st.id)
+        .append(" ".repeat(maxSpaces - spaces));
+
+      String id = st.type.getPrettyId();
+      eb.append(id);
+      eb.append(" ".repeat(maxNameId - id.length()));
+
+      if (st.getParent() != null) {
+        eb.append(" P:").append(st.getParent().id);
+        eb.append(" ".repeat(maxSpaces - charsInId(st.getParent().id)));
+      }
+
+      if (st.getFirst() != null) {
+        eb.append(" F:").append(st.getFirst().id);
+        eb.append(" ".repeat(maxSpaces - charsInId(st.getFirst().id)));
+      }
+      eb.append(" ");
+
+      st.addToTapestry(s -> eb.append("D:").append(s).append(" "));
+
+      sb.append(eb.toString().stripTrailing());
+
+      sb.append("\n");
+    }
+
+    int maxDestSpacing = maxSpaces + 1 + 3 + maxSpaces;
+
+    List<StatEdgeData> edges = stats.stream()
+      .map(stat -> {
+        List<StatEdge> es = stat.getAllSuccessorEdges();
+        if (stat instanceof IfStatement) {
+          IfStatement ifst = (IfStatement) stat;
+          es.add(ifst.getIfEdge());
+          es.add(ifst.getElseEdge());
+        } else if (stat instanceof SwitchStatement) {
+          SwitchStatement swst = (SwitchStatement) stat;
+          es.add(swst.getDefaultEdge());
+        }
+
+        return es;
+      })
+      .flatMap(List::stream)
+      .filter(Objects::nonNull)
+      .distinct()
+      .map(StatEdgeData::new)
+      .collect(Collectors.toList());
+
+    Map<StatEdge, StatEdgeData> edgeMap = edges.stream()
+      .collect(Collectors.toMap(e -> e.edge, e -> e));
+
+    for (Statement st : stats) {
+      if (st instanceof IfStatement) {
+        IfStatement ifStat = (IfStatement) st;
+        edgeMap.get(ifStat.getIfEdge()).ifId = ifStat.id;
+
+        if (ifStat.getElsestat() != null) {
+          edgeMap.get(ifStat.getElseEdge()).elseId = ifStat.id;
+        }
+      }
+
+      if (st instanceof SwitchStatement) {
+        SwitchStatement switchStat = (SwitchStatement) st;
+        edgeMap.get(switchStat.getDefaultEdge()).ifId = switchStat.id;
+      }
+    }
+
+    for (StatEdgeData ed : edges) {
+      StatEdge e = ed.edge;
+
+      StringBuilder eb = new StringBuilder();
+      eb.append(e.getSource().id)
+        .append(" ".repeat(maxSpaces - (charsInId(e.getSource().id) - 1)))
+        .append("-> ")
+        .append(e.getDestination().id);
+
+      eb.append(" ".repeat(Math.max(1, maxDestSpacing - (eb.length() - 1))));
+      String type = e.makeEdgeTypeString();
+      eb.append(type);
+      eb.append(" ".repeat(maxEdgeId - type.length()));
+
+      if (e.closure != null) {
+        eb.append(" C:").append(e.closure.id);
+      } else {
+        eb.append(" ".repeat(maxSpaces + 3));
+      }
+
+      if (e.labeled) {
+        eb.append(" L");
+      }
+
+      if (e.explicit) {
+        eb.append(" E");
+      }
+
+      // Can inline is inverted because it is true by default and only changed in a few places
+      if (!e.canInline) {
+        eb.append(" I");
+      }
+
+      if (e.phantomContinue) {
+        eb.append(" P");
+      }
+
+      if (ed.ifId != -1) {
+        eb.append(" If:").append(ed.ifId);
+      }
+
+      if (ed.elseId != -1) {
+        eb.append(" IfE:").append(ed.elseId);
+      }
+
+      if (ed.defaultId != -1) {
+        eb.append(" D:").append(ed.defaultId);
+      }
+
+      sb.append(eb.toString().stripTrailing());
+
+      sb.append("\n");
+    }
+
+    for (Statement st : stats) {
+      if (st instanceof BasicBlockStatement) {
+        if (st.getExprents() == null || st.getExprents().isEmpty()) {
+          continue;
+        }
+
+        for (Exprent e : st.getExprents()) {
+          serializeExpr(sb, maxSpaces, st, e);
+        }
+      }
+
+      if (st instanceof IfStatement) {
+        serializeExpr(sb, maxSpaces, st, ((IfStatement) st).getHeadexprent());
+      }
+
+      if (st instanceof DoStatement) {
+        DoStatement loop = (DoStatement) st;
+
+        switch (loop.getLooptype()) {
+          case INFINITE:
+            break;
+          case WHILE:
+          case DO_WHILE:
+            serializeExpr(sb, maxSpaces, st, loop.getConditionExprent());
+            break;
+          case FOR:
+            serializeExpr(sb, maxSpaces, st, loop.getInitExprent());
+            serializeExpr(sb, maxSpaces, st, loop.getConditionExprent());
+            serializeExpr(sb, maxSpaces, st, loop.getIncExprent());
+            break;
+          case FOR_EACH:
+            serializeExpr(sb, maxSpaces, st, loop.getInitExprent());
+            serializeExpr(sb, maxSpaces, st, loop.getIncExprent());
+        }
+      }
+    }
+
+    return sb.toString().stripTrailing();
+  }
+
+  private static void serializeExpr(StringBuilder sb, int maxSpaces, Statement st, Exprent e) {
+    StringBuilder eb = new StringBuilder();
+
+    eb.append(st.id);
+    eb.append(" ".repeat(maxSpaces - (charsInId(st.id) - 1)));
+    eb.append("< ");
+
+    e.toTapestry(eb);
+
+    sb.append(eb.toString().stripTrailing());
+
+    sb.append("\n");
+  }
+
+  private static class StatEdgeData {
+    private final StatEdge edge;
+    private int ifId = -1;
+    private int elseId = -1;
+    private int defaultId = -1;
+
+    private StatEdgeData(StatEdge edge) {
+      this.edge = edge;
+    }
+  }
+
+  private static int charsInId(int st) {
+    return Integer.toString(st).length();
+  }
+
+  public static void findAllStats(List<Statement> list, Statement root) {
+    for (Statement stat : root.getStats()) {
+      if (!list.contains(stat)) {
+        list.add(stat);
+      }
+
+      if (stat instanceof IfStatement) {
+        IfStatement ifs = (IfStatement) stat;
+
+        if (ifs.getIfstat() != null && !list.contains(ifs.getIfstat())) {
+          list.add(ifs.getIfstat());
+        }
+
+        if (ifs.getElsestat() != null && !list.contains(ifs.getElsestat())) {
+          list.add(ifs.getElsestat());
+        }
+      }
+
+      findAllStats(list, stat);
+    }
+
+    if (root instanceof RootStatement) {
+      list.add(((RootStatement)root).getDummyExit());
+    }
+  }
+}

--- a/src/org/jetbrains/java/decompiler/modules/serializer/TapestryWriter.java
+++ b/src/org/jetbrains/java/decompiler/modules/serializer/TapestryWriter.java
@@ -116,6 +116,7 @@ public final class TapestryWriter {
       if (st instanceof IfStatement) {
         IfStatement ifStat = (IfStatement) st;
         edgeMap.get(ifStat.getIfEdge()).ifId = ifStat.id;
+        edgeMap.get(ifStat.getIfEdge()).hasIfStat = ifStat.getIfstat() != null;
 
         if (ifStat.getElsestat() != null) {
           edgeMap.get(ifStat.getElseEdge()).elseId = ifStat.id;
@@ -124,7 +125,7 @@ public final class TapestryWriter {
 
       if (st instanceof SwitchStatement) {
         SwitchStatement switchStat = (SwitchStatement) st;
-        edgeMap.get(switchStat.getDefaultEdge()).ifId = switchStat.id;
+        edgeMap.get(switchStat.getDefaultEdge()).defaultId = switchStat.id;
       }
     }
 
@@ -166,7 +167,11 @@ public final class TapestryWriter {
       }
 
       if (ed.ifId != -1) {
-        eb.append(" If:").append(ed.ifId);
+        if (ed.hasIfStat) {
+          eb.append(" If:").append(ed.ifId);
+        } else {
+          eb.append(" IfN:").append(ed.ifId);
+        }
       }
 
       if (ed.elseId != -1) {
@@ -241,6 +246,7 @@ public final class TapestryWriter {
     private int ifId = -1;
     private int elseId = -1;
     private int defaultId = -1;
+    private boolean hasIfStat = false;
 
     private StatEdgeData(StatEdge edge) {
       this.edge = edge;

--- a/src/org/jetbrains/java/decompiler/struct/gen/VarType.java
+++ b/src/org/jetbrains/java/decompiler/struct/gen/VarType.java
@@ -120,6 +120,47 @@ public class VarType {  // TODO: optimize switch
     this.falseBoolean = false;
   }
 
+  public String toTapestryString() {
+    return this.value.replaceAll("\\[", "{");
+  }
+
+  public static VarType fromTapestryString(String tapestryString) {
+    String s = tapestryString.replaceAll("\\{", "[");
+    if (s.length() == 1) {
+      switch (s) {
+        case "B":
+          return VarType.VARTYPE_BYTE;
+        case "C":
+          return VarType.VARTYPE_CHAR;
+        case "D":
+          return VarType.VARTYPE_DOUBLE;
+        case "F":
+          return VarType.VARTYPE_FLOAT;
+        case "I":
+          return VarType.VARTYPE_INT;
+        case "J":
+          return VarType.VARTYPE_LONG;
+        case "S":
+          return VarType.VARTYPE_SHORT;
+        case "Z":
+          return VarType.VARTYPE_BOOLEAN;
+        case "V":
+          return VarType.VARTYPE_VOID;
+        case "X":
+          return VarType.VARTYPE_BYTECHAR;
+        case "Y":
+          return VarType.VARTYPE_SHORTCHAR;
+        case "U":
+          return VarType.VARTYPE_UNKNOWN;
+        default:
+          return new VarType(s);
+      }
+    }
+    else {
+      return new VarType(s);
+    }
+  }
+
   private static String getChar(int type) {
     switch (type) {
       case CodeConstants.TYPE_BYTE:

--- a/src/org/jetbrains/java/decompiler/util/DotExporter.java
+++ b/src/org/jetbrains/java/decompiler/util/DotExporter.java
@@ -17,6 +17,7 @@ import org.jetbrains.java.decompiler.modules.decompiler.vars.VarVersionEdge;
 import org.jetbrains.java.decompiler.modules.decompiler.vars.VarVersionNode;
 import org.jetbrains.java.decompiler.modules.decompiler.vars.VarVersionPair;
 import org.jetbrains.java.decompiler.modules.decompiler.vars.VarVersionsGraph;
+import org.jetbrains.java.decompiler.modules.serializer.TapestryWriter;
 import org.jetbrains.java.decompiler.struct.StructMethod;
 import org.jetbrains.java.decompiler.util.collections.FastSparseSetFactory.FastSparseSet;
 import org.jetbrains.java.decompiler.util.collections.SFormsFastMapDirect;
@@ -65,7 +66,7 @@ public class DotExporter {
 
     List<Statement> stats = new ArrayList<>();
     stats.add(stat);
-    findAllStats(stats, stat);
+    TapestryWriter.findAllStats(stats, stat);
 
     DummyExitStatement exit = null;
     if (stat instanceof RootStatement) {
@@ -386,28 +387,6 @@ public class DotExporter {
       case DUMMY_EXIT: return "Dummy Exit";
       case SEQUENCE: return "Sequence";
       default: return "Unknown";
-    }
-  }
-
-  private static void findAllStats(List<Statement> list, Statement root) {
-    for (Statement stat : root.getStats()) {
-      if (!list.contains(stat)) {
-        list.add(stat);
-      }
-
-      if (stat instanceof IfStatement) {
-        IfStatement ifs = (IfStatement) stat;
-
-        if (ifs.getIfstat() != null && !list.contains(ifs.getIfstat())) {
-          list.add(ifs.getIfstat());
-        }
-
-        if (ifs.getElsestat() != null && !list.contains(ifs.getElsestat())) {
-          list.add(ifs.getElsestat());
-        }
-      }
-
-      findAllStats(list, stat);
     }
   }
 

--- a/test/org/jetbrains/java/decompiler/MinimalQuiltflowerEnvironment.java
+++ b/test/org/jetbrains/java/decompiler/MinimalQuiltflowerEnvironment.java
@@ -12,7 +12,7 @@ import java.util.HashMap;
  *
  * @author SuperCoder79
  */
-public final class MinimalFernflowerEnvironment {
+public final class MinimalQuiltflowerEnvironment {
   public static void setup() {
     StructContext sc = new StructContext(null, null, null);
     DecompilerContext context = new DecompilerContext(

--- a/test/org/jetbrains/java/decompiler/MinimalQuiltflowerEnvironment.java
+++ b/test/org/jetbrains/java/decompiler/MinimalQuiltflowerEnvironment.java
@@ -3,6 +3,7 @@ package org.jetbrains.java.decompiler;
 import org.jetbrains.java.decompiler.main.ClassesProcessor;
 import org.jetbrains.java.decompiler.main.DecompilerContext;
 import org.jetbrains.java.decompiler.main.decompiler.PrintStreamLogger;
+import org.jetbrains.java.decompiler.main.extern.IFernflowerPreferences;
 import org.jetbrains.java.decompiler.struct.StructContext;
 
 import java.util.HashMap;
@@ -16,7 +17,7 @@ public final class MinimalQuiltflowerEnvironment {
   public static void setup() {
     StructContext sc = new StructContext(null, null, null);
     DecompilerContext context = new DecompilerContext(
-      new HashMap<>(),
+      IFernflowerPreferences.getDefaults(),
       new PrintStreamLogger(System.out),
       sc,
       new ClassesProcessor(sc),

--- a/test/org/jetbrains/java/decompiler/StronglyConnectedComponentsTest.java
+++ b/test/org/jetbrains/java/decompiler/StronglyConnectedComponentsTest.java
@@ -17,7 +17,7 @@ public class StronglyConnectedComponentsTest {
   // Ensures that strongly connected component calculation remains the same.
   @Test
   public void testSCCs() {
-    MinimalFernflowerEnvironment.setup();
+    MinimalQuiltflowerEnvironment.setup();
 
     // Create a simple 0 <--> 1 relationship
     Statement bb = new BasicBlockStatement(new BasicBlock(0));

--- a/test/org/jetbrains/java/decompiler/ir/IdentifyLabelsTest.java
+++ b/test/org/jetbrains/java/decompiler/ir/IdentifyLabelsTest.java
@@ -1,0 +1,21 @@
+package org.jetbrains.java.decompiler.ir;
+
+import org.jetbrains.java.decompiler.modules.decompiler.LabelHelper;
+import org.jetbrains.java.decompiler.modules.decompiler.stats.RootStatement;
+
+public class IdentifyLabelsTest extends IrTestBase {
+  @Override
+  protected void registerAll() {
+    register("TestLoopBreak");
+  }
+
+  @Override
+  protected String transformName() {
+    return "IdentifyLabels";
+  }
+
+  @Override
+  protected void runTransform(RootStatement root) {
+    LabelHelper.identifyLabels(root);
+  }
+}

--- a/test/org/jetbrains/java/decompiler/ir/IdentifyLabelsTest.java
+++ b/test/org/jetbrains/java/decompiler/ir/IdentifyLabelsTest.java
@@ -7,6 +7,9 @@ public class IdentifyLabelsTest extends IrTestBase {
   @Override
   protected void registerAll() {
     register("TestLoopBreak");
+    register("TestLoopBreakEmptyIf");
+    register("TestLiftSequenceLabel");
+    register("TestIfElse");
   }
 
   @Override

--- a/test/org/jetbrains/java/decompiler/ir/IrTestBase.java
+++ b/test/org/jetbrains/java/decompiler/ir/IrTestBase.java
@@ -1,0 +1,68 @@
+package org.jetbrains.java.decompiler.ir;
+
+import org.jetbrains.java.decompiler.DecompilerTestFixture;
+import org.jetbrains.java.decompiler.MinimalQuiltflowerEnvironment;
+import org.jetbrains.java.decompiler.modules.decompiler.stats.RootStatement;
+import org.jetbrains.java.decompiler.modules.serializer.TapestryReader;
+import org.jetbrains.java.decompiler.modules.serializer.TapestryWriter;
+import org.junit.jupiter.api.*;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+public abstract class IrTestBase {
+  private final List<String> tests = new ArrayList<>();
+
+  protected abstract void registerAll();
+
+  protected abstract String transformName();
+
+  protected abstract void runTransform(RootStatement root);
+
+  protected void register(String name) {
+    tests.add(name);
+  }
+
+  @TestFactory
+  @DisplayName("Quiltflower IR Tests")
+  public Stream<DynamicContainer> testRegistered() {
+    tests.clear();
+    registerAll();
+
+    return Stream.of(
+      DynamicContainer.dynamicContainer(transformName() + " Tests",
+          makeTests()
+        )
+    );
+  }
+
+  protected Stream<DynamicNode> makeTests() {
+    Path baseDir = new DecompilerTestFixture().getTestDataDir().resolve("transforms/" + transformName() + "/");
+    Path outDir = new DecompilerTestFixture().getTestDataDir().resolve("results/transforms/" + transformName() + "/");
+
+    return tests.stream().map(s -> {
+      return DynamicTest.dynamicTest(s, () -> {
+        MinimalQuiltflowerEnvironment.setup();
+        String input = Files.readString(baseDir.resolve(s + ".qir"));
+        RootStatement root = TapestryReader.readTapestry(input);
+        runTransform(root);
+
+        String output = TapestryWriter.serialize(root);
+
+        Path outPath = outDir.resolve(s + ".qir");
+        if (outPath.toFile().exists()) {
+          assertEquals(Files.readString(outPath).replace("\r\n", "\n"), output);
+        } else {
+          assumeTrue(false, outPath + " was not present yet");
+          Files.writeString(outPath, output);
+        }
+      });
+    });
+  }
+}

--- a/testData/results/transforms/IdentifyLabels/TestIfElse.res
+++ b/testData/results/transforms/IdentifyLabels/TestIfElse.res
@@ -1,0 +1,19 @@
+11 Root  F:12
+12 If    P:11 F:1  D:IfElse D:Neg
+8  Block P:12
+7  Block P:12
+1  Block P:12
+9  Exit
+1  -> 8  Regular        L E If:12
+1  -> 7  Regular        L E IfE:12
+8  -> 9  BreakExit C:12
+7  -> 9  BreakExit C:12
+12 < [If [Func BOOL_NOT [Func GT [Var U 2] [Const X 0]]]]
+8  < [Return RETURN I [Const I 0]]
+7  < [Return RETURN I [Const I 1]]
+=======================================
+if (!(var2 > 0)) {
+   return 0;
+} else {
+   return 1;
+}

--- a/testData/results/transforms/IdentifyLabels/TestLiftSequenceLabel.res
+++ b/testData/results/transforms/IdentifyLabels/TestLiftSequenceLabel.res
@@ -1,0 +1,34 @@
+8  Root  F:16
+16 Do    P:8  F:19 D:Do
+19 Seq   P:16 F:13
+13 If    P:19 F:1  D:If D:Neg
+18 Seq   P:13 F:11
+1  Block P:13
+11 If    P:18 F:2  D:If D:Matched
+4  Block P:19
+2  Block P:11
+5  Block P:18
+6  Exit
+13 -> 4  Regular        L
+1  -> 18 Regular        L E If:13
+11 -> 5  Regular        L
+2  -> 4  Break     C:13 L E If:11
+4  -> 16 Continue  C:16 L
+5  -> 6  BreakExit C:16 E
+13 < [If [Func GE [Invoke hashCode java/lang/Object ()I VIRTUAL [Var U 1]] [Const I 0]]]
+11 < [If [Func NE [Func INSTANCEOF [Var U 1] [Const java/lang/String null] [Var java/lang/String 2]] [Const Z 0]]]
+4  < [Invoke println java/io/PrintStream (Ljava/lang/Object;)V VIRTUAL [Field out java/lang/System Ljava/io/PrintStream;] [Var U 1]]
+5  < [Return RETURN V]
+=======================================
+while(true) {
+   label13:
+   if (var1.hashCode() >= 0) {
+      if (var1 instanceof "null" var2 != false) {
+         System.out.println(var1);
+      }
+
+      return;
+   }
+
+   System.out.println(var1);
+}

--- a/testData/results/transforms/IdentifyLabels/TestLoopBreak.qir
+++ b/testData/results/transforms/IdentifyLabels/TestLoopBreak.qir
@@ -1,0 +1,17 @@
+8  Root  F:13
+13 Seq   P:8  F:12
+12 Do    P:13 F:9  D:While
+9  If    P:12 F:2  D:If D:Neg D:PPMM
+4  Block P:9
+2  Block P:9
+5  Block P:13
+6  Exit
+12 -> 5  Regular        L
+9  -> 5  Break     C:12 E
+2  -> 4  Regular        L E If:9
+4  -> 12 Continue  C:12 E
+5  -> 6  BreakExit C:12
+12 < [Func GT [Var U 1] [Const I 10]]
+9  < [If [Func BOOL_NOT [Func EQ [Func PPI I [Var U 1]] [Const I 15]]]]
+4  < [Invoke println java/io/PrintStream (I)V VIRTUAL [Field out java/lang/System Ljava/io/PrintStream;] [Const I 0]]
+5  < [Return RETURN V]

--- a/testData/results/transforms/IdentifyLabels/TestLoopBreak.res
+++ b/testData/results/transforms/IdentifyLabels/TestLoopBreak.res
@@ -6,23 +6,22 @@
 2  Block P:9
 5  Block P:13
 6  Exit
-12 -> 5  Regular        L E
-9  -> 5  Break     C:12 L E
+12 -> 5  Regular        L
+9  -> 5  Break     C:12 E
 2  -> 4  Regular        L E If:9
-4  -> 12 Continue  C:12 L E
-5  -> 6  BreakExit C:12 L E
+4  -> 12 Continue  C:12 E
+5  -> 6  BreakExit C:12
 12 < [Func GT [Var U 1] [Const I 10]]
 9  < [If [Func BOOL_NOT [Func EQ [Func PPI I [Var U 1]] [Const I 15]]]]
 4  < [Invoke println java/io/PrintStream (I)V VIRTUAL [Field out java/lang/System Ljava/io/PrintStream;] [Const I 0]]
 5  < [Return RETURN V]
 =======================================
-label12:
 while(var1 > 10) {
    if (!(++var1 == 15)) {
       System.out.println(0);
-      continue label12;
+      continue;
    }
-   break label12;
+   break;
 }
 
 return;

--- a/testData/results/transforms/IdentifyLabels/TestLoopBreakEmptyIf.res
+++ b/testData/results/transforms/IdentifyLabels/TestLoopBreakEmptyIf.res
@@ -2,16 +2,22 @@
 13 Seq   P:8  F:12
 12 Do    P:13 F:9  D:While
 9  If    P:12 F:2  D:If D:Neg D:PPMM
-4  Block P:9
 2  Block P:9
 5  Block P:13
 6  Exit
 12 -> 5  Regular        L
 9  -> 5  Break     C:12 E
-2  -> 4  Regular        L E If:9
-4  -> 12 Continue  C:12 E
+2  -> 12 Continue  C:12 E IfN:9
 5  -> 6  BreakExit C:12
 12 < [Func GT [Var U 1] [Const I 10]]
 9  < [If [Func BOOL_NOT [Func EQ [Func PPI I [Var U 1]] [Const I 15]]]]
-4  < [Invoke println java/io/PrintStream (I)V VIRTUAL [Field out java/lang/System Ljava/io/PrintStream;] [Const I 0]]
 5  < [Return RETURN V]
+=======================================
+while(var1 > 10) {
+   if (!(++var1 == 15)) {
+      continue;
+   }
+   break;
+}
+
+return;

--- a/testData/transforms/IdentifyLabels/TestIfElse.qir
+++ b/testData/transforms/IdentifyLabels/TestIfElse.qir
@@ -1,0 +1,20 @@
+11 Root  F:12
+12 If    P:11 F:1  D:IfElse D:Neg
+8  Block P:12
+1  Block P:12
+7  Block P:12
+9  Exit
+1  -> 8  Regular        L E If:12
+1  -> 7  Regular        L E IfE:12
+8  -> 9  BreakExit C:12 L E
+7  -> 9  BreakExit C:12 L E
+12 < [If [Func BOOL_NOT [Func GT [Var U 2] [Const X 0]]]]
+8  < [Return RETURN I [Const X 0]]
+7  < [Return RETURN I [Const X 1]]
+=======================================
+label12:
+if (!(var2 > 0)) {
+   return 0;
+} else {
+   return 1;
+}

--- a/testData/transforms/IdentifyLabels/TestLiftSequenceLabel.qir
+++ b/testData/transforms/IdentifyLabels/TestLiftSequenceLabel.qir
@@ -1,0 +1,38 @@
+8  Root  F:16
+16 Do    P:8  F:19 D:Do
+19 Seq   P:16 F:13
+13 If    P:19 F:1  D:If D:Neg
+18 Seq   P:13 F:11
+1  Block P:13
+11 If    P:18 F:2  D:If D:Matched
+2  Block P:11
+5  Block P:18
+4  Block P:19
+6  Exit
+13 -> 4  Regular        L E
+1  -> 18 Regular        L E If:13
+11 -> 5  Regular        L E
+2  -> 4  Break     C:18 L E If:11
+5  -> 6  BreakExit C:16 L E
+4  -> 16 Continue  C:16 L E
+13 < [If [Func GE [Invoke hashCode java/lang/Object ()I VIRTUAL [Var U 1]] [Const X 0]]]
+11 < [If [Func NE [Func INSTANCEOF [Var U 1] [Const java/lang/String null] [Var java/lang/String 2]] [Const Z 0]]]
+5  < [Return RETURN V]
+4  < [Invoke println java/io/PrintStream (Ljava/lang/Object;)V VIRTUAL [Field out java/lang/System Ljava/io/PrintStream;] [Var U 1]]
+=======================================
+label16:
+while(true) {
+   if (var1.hashCode() >= 0) {
+      label18: {
+         if (var1 instanceof "null" var2 != false) {
+            System.out.println(var1);
+            continue label16;
+         }
+
+         return;
+      }
+   }
+
+   System.out.println(var1);
+   continue label16;
+}

--- a/testData/transforms/IdentifyLabels/TestLoopBreak.qir
+++ b/testData/transforms/IdentifyLabels/TestLoopBreak.qir
@@ -1,0 +1,17 @@
+8  Root  F:13
+13 Seq   P:8  F:12
+12 Do    P:13 F:9  D:While
+9  If    P:12 F:2  D:If D:Neg D:PPMM
+4  Block P:9
+2  Block P:9
+5  Block P:13
+6  Exit
+12 -> 5  Regular        L E
+9  -> 5  Break     C:12 L E
+2  -> 4  Regular        L E If:9
+4  -> 12 Continue  C:12 L E
+5  -> 6  BreakExit C:12 L E
+12 < [Func GT [Var U 1] [Const I 10]]
+9  < [If [Func BOOL_NOT [Func EQ [Func PPI I [Var U 1]] [Const I 15]]]]
+4  < [Invoke println java/io/PrintStream (I)V VIRTUAL [Field out java/lang/System Ljava/io/PrintStream;] [Const I 0]]
+5  < [Return RETURN V]

--- a/testData/transforms/IdentifyLabels/TestLoopBreakEmptyIf.qir
+++ b/testData/transforms/IdentifyLabels/TestLoopBreakEmptyIf.qir
@@ -2,24 +2,20 @@
 13 Seq   P:8  F:12
 12 Do    P:13 F:9  D:While
 9  If    P:12 F:2  D:If D:Neg D:PPMM
-4  Block P:9
 2  Block P:9
 5  Block P:13
 6  Exit
 12 -> 5  Regular        L E
 9  -> 5  Break     C:12 L E
-2  -> 4  Regular        L E If:9
-4  -> 12 Continue  C:12 L E
+2  -> 12 Continue   C:12 L E IfN:9
 5  -> 6  BreakExit C:12 L E
 12 < [Func GT [Var U 1] [Const I 10]]
 9  < [If [Func BOOL_NOT [Func EQ [Func PPI I [Var U 1]] [Const I 15]]]]
-4  < [Invoke println java/io/PrintStream (I)V VIRTUAL [Field out java/lang/System Ljava/io/PrintStream;] [Const I 0]]
 5  < [Return RETURN V]
 =======================================
 label12:
 while(var1 > 10) {
    if (!(++var1 == 15)) {
-      System.out.println(0);
       continue label12;
    }
    break label12;


### PR DESCRIPTION
This PR adds a string-based internal representation for the statement graph and exprent tree, and adds a notion of "IR tests": tests that only run a single pass from the pass pipeline and analyze the statements, edges, and expressions that results from the change. This allows for deep inspection of how the pass is structurally modifying the graph.

Before this PR can be merged, more work need to be done in these areas:
* Fully commenting and explaining the new code, as it is substantially nontrivial.
* Ensure all statements and expressions are compatible with the serializer and deserializer.
* Adding more IR tests, as there is only a single proof of concept test at the moment.
* Merge with plugins.