### PR TITLE
fix: prepare for publishing exclusively to Central

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,9 +15,7 @@ jobs:
       - uses: gradle/wrapper-validation-action@v1
       - run: ./gradlew build publish publishToSonatype closeAndReleaseSonatypeStagingRepository -x test --stacktrace
         env:
-          MAVEN_URL: ${{ secrets.MAVEN_URL }}
-          MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
           SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
-          SIGNING_KEY_PASSPHRASE : ${{ secrets.SIGNING_KEY_PASSPHRASE  }}
-          SONATYPE_USER : ${{ secrets.SONATYPE_USER  }}
+          SIGNING_KEY_PASSPHRASE: ${{ secrets.SIGNING_KEY_PASSPHRASE }}
+          SONATYPE_USER: ${{ secrets.SONATYPE_USER }}
           SONATYPE_PASS: ${{ secrets.SONATYPE_PASS }}

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -12,6 +12,7 @@ jobs:
       - uses: gradle/wrapper-validation-action@v1
       - run: ./gradlew publish --stacktrace
         env:
-          SNAPSHOTS_URL: ${{ secrets.SNAPSHOTS_URL }}
-          SNAPSHOTS_USERNAME: ${{ secrets.SNAPSHOTS_USERNAME }}
-          SNAPSHOTS_PASSWORD: ${{ secrets.SNAPSHOTS_PASSWORD }}
+          SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
+          SIGNING_KEY_PASSPHRASE: ${{ secrets.SIGNING_KEY_PASSPHRASE }}
+          SONATYPE_USER: ${{ secrets.SONATYPE_USER }}
+          SONATYPE_PASS: ${{ secrets.SONATYPE_PASS }}

--- a/build.gradle
+++ b/build.gradle
@@ -199,7 +199,7 @@ publishing {
         packaging = 'jar'
         // optionally artifactId can be defined here
         description = 'Modern Java & JVM language decompiler aiming to be as accurate as possible, with an emphasis on output quality.'
-        url = 'https://github.com/Vineflower/vineflower'
+        url = 'https://vineflower.org'
 
         scm {
           connection = 'scm:git:https://github.com/Vineflower/vineflower.git'
@@ -234,25 +234,6 @@ publishing {
 
   // select the repositories you want to publish to
   repositories {
-    if (ENV.MAVEN_URL) {
-      maven {
-        url ENV.MAVEN_URL
-        credentials {
-          username ENV.MAVEN_USERNAME
-          password ENV.MAVEN_PASSWORD
-        }
-      }
-    }
-
-    if (ENV.SNAPSHOTS_URL) {
-      maven {
-        url ENV.SNAPSHOTS_URL
-        credentials {
-          username ENV.SNAPSHOTS_USERNAME
-          password ENV.SNAPSHOTS_PASSWORD
-        }
-      }
-    }
 
     if (ENV.SONATYPE_USER) {
       maven {
@@ -273,6 +254,7 @@ nexusPublishing {
       password = ENV.SONATYPE_PASS
 
       nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
+      snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
     }
   }
 }


### PR DESCRIPTION
This updates publishing configuration to publish both releases and snapshots only to Central. Pending configuration of secrets for OSSRH auth and GPG keys.