### PR TITLE
Fix local variable jad name and type where the debug name conflicts

### DIFF
--- a/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
+++ b/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
@@ -270,10 +270,20 @@ public class NestedClassProcessor {
 
     // rename colliding local variables
     for (VarVersionPair local : varProc.getUsedVarVersions()) {
-      String name = varProc.getVarName(local);
+      String name = null;
+      LocalVariable lvt = varProc.getVarLVT(local);
+      if (lvt != null) {
+        name = lvt.getName();
+      }
+      if (name == null) {
+        name = varProc.getVarName(local);
+      }
       if (usedBefore.contains(name) && !"this".equals(name)) {
-        mapNewNames.put(local, enclosingCollector.getFreeName(name));
-        lvts.put(local, varProc.getVarLVT(local));
+        name = enclosingCollector.getFreeName(name);
+        mapNewNames.put(local, name);
+        if (lvt != null) {
+          lvts.put(local, lvt.rename(name));
+        }
       }
     }
 

--- a/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
+++ b/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
@@ -273,6 +273,7 @@ public class NestedClassProcessor {
       String name = varProc.getVarName(local);
       if (usedBefore.contains(name) && !"this".equals(name)) {
         mapNewNames.put(local, enclosingCollector.getFreeName(name));
+        lvts.put(local, varProc.getVarLVT(local));
       }
     }
 


### PR DESCRIPTION
Fixes cases in lambdas where the debug local variable name is used instead of the jad styled local variable name along with in certain cases the type of the local variable not being correct.