### PR TITLE
Fix final variable definition that is used in a for loop being moved outside the for loop

### DIFF
--- a/src/org/jetbrains/java/decompiler/modules/decompiler/MergeHelper.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/MergeHelper.java
@@ -433,7 +433,7 @@ public class MergeHelper {
         return;
       }
 
-      // Check if any final variable assignments in the loop are
+      // Check if any final variable assignments in the loop are used in the line that is being moved to the final part of the for loop
       Set<VarExprent> finalVariables = getFinalVariables(stat, new HashSet<>());
       if (finalVariables.stream().anyMatch(exp -> exp.isVarReferenced(lastExp))) {
         return;

--- a/test/org/jetbrains/java/decompiler/SingleClassesTest.java
+++ b/test/org/jetbrains/java/decompiler/SingleClassesTest.java
@@ -670,6 +670,8 @@ public class SingleClassesTest extends SingleClassesTestBase {
     // TODO: switch (s) decompiled as switch (s.hashCode())
     register(JAVA_17, "TestSingleCaseStrSwitch");
     register(JAVA_16, "TestIfPatternMatchMethod");
+    
+    register(JAVA_8, "TestWhileLambda");
   }
 
   private void registerEntireClassPath() {

--- a/testData/results/pkg/TestWhileLambda.dec
+++ b/testData/results/pkg/TestWhileLambda.dec
@@ -1,0 +1,39 @@
+package pkg;
+
+import java.util.function.Supplier;
+
+public class TestWhileLambda {
+   public void test() {
+      Object o = new Object();// 7
+
+      while (o != null) {// 8
+         Object o2 = new Object();// 9
+         Supplier var3 = () -> o2;// 10
+      }
+   }// 12
+}
+
+class 'pkg/TestWhileLambda' {
+   method 'test ()V' {
+      7      6
+      8      8
+      9      8
+      13      9
+      1a      10
+      1e      12
+   }
+
+   method 'lambda$test$0 (Ljava/lang/Object;)Ljava/lang/Object;' {
+      0      10
+      1      10
+   }
+}
+
+Lines mapping:
+7 <-> 7
+8 <-> 9
+9 <-> 10
+10 <-> 11
+12 <-> 13
+Not mapped:
+11

--- a/testData/src/java8/pkg/TestWhileLambda.java
+++ b/testData/src/java8/pkg/TestWhileLambda.java
@@ -1,0 +1,13 @@
+package pkg;
+
+import java.util.function.Supplier;
+
+public class TestWhileLambda {
+    public void test() {
+        Object o = new Object();
+        while (o != null) {
+            Object o2 = new Object();
+            Supplier<Object> s = () -> o2;
+        }
+    }
+}


### PR DESCRIPTION
Fixes a compile error in `RealmsSelectWorldTemplateScreen` where a variable is used in a lambda but the definition is being moved outside a for loop causing the variable to no longer be effectively final.