### PR TITLE
Make containsKey return true if the key is present and the value is null in NullableConcurrentHashMap

### DIFF
--- a/src/org/jetbrains/java/decompiler/util/collections/NullableConcurrentHashMap.java
+++ b/src/org/jetbrains/java/decompiler/util/collections/NullableConcurrentHashMap.java
@@ -44,7 +44,7 @@ public class NullableConcurrentHashMap<K,V> extends ConcurrentHashMap<K,V> {
       key = NULL_KEY;
     }
 
-    return super.containsKey(key);
+    return super.get(key) != null;
   }
 
   @Override

--- a/testData/results/pkg/TestGenericsInvocUnchecked.dec
+++ b/testData/results/pkg/TestGenericsInvocUnchecked.dec
@@ -2,7 +2,7 @@ package pkg;
 
 public class TestGenericsInvocUnchecked<T extends Number> {
    public void test(int i, TestGenericsInvocUnchecked<?> other) {
-      new TestGenericsInvocUnchecked.Inner().testInner(i, this, (TestGenericsInvocUnchecked<T>)other);// 11
+      new TestGenericsInvocUnchecked.Inner().testInner(i, this, other);// 11
    }// 12
 
    public void test1(Class<?> c, String s) {


### PR DESCRIPTION
`super.containsKey` calls `this.get(key)` and returns true if the value is not null which means if the key is in the map and the value is null then `containsKey` returns false.