### PR TITLE
Fix potential exception by removing put outside computeIfAbsent

### DIFF
--- a/src/org/jetbrains/java/decompiler/struct/StructContext.java
+++ b/src/org/jetbrains/java/decompiler/struct/StructContext.java
@@ -75,10 +75,6 @@ public class StructContext {
         try {
           DecompilerContext.getLogger().writeMessage("Loading Class: " + key + " from " + unitForClass.getName(), IFernflowerLogger.Severity.INFO);
           StructClass clazz = StructClass.create(new DataInputFullStream(unitForClass.getClassBytes(key)), unitForClass.isOwn());
-          if (!key.equals(clazz.qualifiedName)) {
-            // also place the class in the right key if it's wrong
-            this.classes.put(clazz.qualifiedName, clazz);
-          }
           return clazz;
         } catch (final IOException ex) {
           DecompilerContext.getLogger().writeMessage("Failed to read class " + key + " from " + unitForClass.getName(), IFernflowerLogger.Severity.ERROR, ex);
@@ -86,6 +82,10 @@ public class StructContext {
       }
       return getSentinel();
     });
+    if (!name.equals(ret.qualifiedName)) {
+      // also place the class in the right key if it's wrong
+      this.classes.putIfAbsent(ret.qualifiedName, ret);
+    }
     return ret == getSentinel() ? null : ret;
   }
 


### PR DESCRIPTION
this.classes is a ConcurrentHashMap. The originalCode try to put something into this.classes inside computeIfAbsent. computeIfAbsent will acquire lock of certain slot of the ConcurrentHashMap. If clazz.qualifiedName end up in the same slot, it will also try to accquire the same lock, which is already held by the same thread, will cause "java.lang.IllegalStateException: Recursive update" 
[demo.zip](https://github.com/Vineflower/vineflower/files/12865482/demo.zip)
This is a small jar file that will trigger the excetpion.