### PR TITLE
Fix variable namer parent not being set for local classes

### DIFF
--- a/plugins/variable-renaming/src/test/java/org/vineflower/variablerenaming/VariableRenamingTest.java
+++ b/plugins/variable-renaming/src/test/java/org/vineflower/variablerenaming/VariableRenamingTest.java
@@ -13,6 +13,7 @@ public class VariableRenamingTest extends SingleClassesTestBase {
         register(JAVA_8, "TestJADNaming");
         // TODO: loop part fails
         registerRaw(CUSTOM, "TestJadLvtCollision"); // created by placing a class in java8 sources and remapping its param using tinyremapper
+        register(JAVA_8, "TestJADLocalClasses");
       }, IFernflowerPreferences.BYTECODE_SOURCE_MAPPING, "1",
       IFernflowerPreferences.DUMP_ORIGINAL_LINES, "1",
       IFernflowerPreferences.DUMP_EXCEPTION_ON_ERROR, "0",

--- a/plugins/variable-renaming/testData/results/pkg/TestJADLocalClasses.dec
+++ b/plugins/variable-renaming/testData/results/pkg/TestJADLocalClasses.dec
@@ -1,0 +1,38 @@
+package pkg;
+
+public class TestJADLocalClasses {
+   public void function() {
+      int i = 0;// 5
+
+      class Test {
+         Test() {
+            int j = 0;// 8
+         }// 9
+      }
+
+   }// 11
+}
+
+class 'pkg/TestJADLocalClasses' {
+   method 'function ()V' {
+      0      4
+      1      4
+      2      12
+   }
+}
+
+class 'pkg/TestJADLocalClasses$1Test' {
+   method '<init> (Lpkg/TestJADLocalClasses;)V' {
+      9      8
+      a      8
+      b      9
+   }
+}
+
+Lines mapping:
+5 <-> 5
+8 <-> 9
+9 <-> 10
+11 <-> 13
+Not mapped:
+7

--- a/plugins/variable-renaming/testData/src/java8/pkg/TestJADLocalClasses.java
+++ b/plugins/variable-renaming/testData/src/java8/pkg/TestJADLocalClasses.java
@@ -1,0 +1,12 @@
+package pkg;
+
+public class TestJADLocalClasses {
+    public void function() {
+        int a = 0;
+        class Test {
+            Test() {
+                int b = 0;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Local classes are only added to the method body after parent contexts are added.