### PR TITLE
Don't tear down nested class wrappers after writing the root class

### DIFF
--- a/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java
+++ b/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java
@@ -563,9 +563,8 @@ public class ClassesProcessor implements CodeConstants {
     node.classStruct.releaseResources();
     node.classStruct.getMethods().forEach(m -> m.clearVariableNamer());
 
-    for (ClassNode nd : node.nested) {
-      destroyWrappers(nd);
-    }
+    // Don't destroy inner node wrappers, they may still be needed to process constructor
+    // invocations etc. from other classes.
   }
 
   public Map<String, ClassNode> getMapRootClasses() {


### PR DESCRIPTION
They may be needed later when writing other classes.

This fixes an issue where non-static inner class constructor invocations from foreign classes would inconsistently have the synthetic enclosing this instance removed from the parameter list, depending on the order they were processed in (and consequently having strange interactions with multithreaded writing)