### PR TITLE
Add option to exclude classes from decompilation with regex

### DIFF
--- a/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java
+++ b/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java
@@ -36,6 +36,8 @@ import java.io.IOException;
 import java.util.*;
 import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class ClassesProcessor implements CodeConstants {
   public static final int AVERAGE_CLASS_SIZE = 16 * 1024;
@@ -94,8 +96,17 @@ public class ClassesProcessor implements CodeConstants {
     boolean bDecompileInner = DecompilerContext.getOption(IFernflowerPreferences.DECOMPILE_INNER);
     boolean verifyAnonymousClasses = DecompilerContext.getOption(IFernflowerPreferences.VERIFY_ANONYMOUS_CLASSES);
 
+    Matcher excludedMatcher = null;
+    String excludedRegex = DecompilerContext.getProperty(IFernflowerPreferences.EXCLUDED_CLASS_REGEX).toString();
+    if (!excludedRegex.isEmpty()) {
+      excludedMatcher = Pattern.compile(excludedRegex).matcher("");
+    }
+
     // create class nodes
     for (StructClass cl : context.getOwnClasses()) {
+      if (excludedMatcher != null && excludedMatcher.reset(cl.qualifiedName).matches()) {
+        continue;
+      }
       if (!mapRootClasses.containsKey(cl.qualifiedName)) {
         if (bDecompileInner) {
           StructInnerClassesAttribute inner = cl.getAttribute(StructGeneralAttribute.ATTRIBUTE_INNER_CLASSES);

--- a/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java
+++ b/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java
@@ -97,7 +97,7 @@ public class ClassesProcessor implements CodeConstants {
     boolean verifyAnonymousClasses = DecompilerContext.getOption(IFernflowerPreferences.VERIFY_ANONYMOUS_CLASSES);
 
     Matcher excludedMatcher = null;
-    String excludedRegex = DecompilerContext.getProperty(IFernflowerPreferences.EXCLUDED_CLASS_REGEX).toString();
+    String excludedRegex = DecompilerContext.getProperty(IFernflowerPreferences.EXCLUDED_CLASSES).toString();
     if (!excludedRegex.isEmpty()) {
       excludedMatcher = Pattern.compile(excludedRegex).matcher("");
     }

--- a/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java
+++ b/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java
@@ -385,6 +385,7 @@ public interface IFernflowerPreferences {
   @Name("Excluded Class Regex")
   @Description("Exclude classes from decompilation if their fully qualified names match the specified regular expression.")
   @ShortName("exc")
+  @Type(Type.STRING)
   String EXCLUDED_CLASS_REGEX = "excluded-class-regex";
 
   Map<String, Object> DEFAULTS = getDefaults();

--- a/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java
+++ b/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java
@@ -382,11 +382,10 @@ public interface IFernflowerPreferences {
   @ShortName("mcs")
   String MARK_CORRESPONDING_SYNTHETICS = "mark-corresponding-synthetics";
 
-  @Name("Excluded Class Regex")
+  @Name("Excluded Classes")
   @Description("Exclude classes from decompilation if their fully qualified names match the specified regular expression.")
-  @ShortName("exc")
   @Type(Type.STRING)
-  String EXCLUDED_CLASS_REGEX = "excluded-class-regex";
+  String EXCLUDED_CLASSES = "excluded-classes";
 
   Map<String, Object> DEFAULTS = getDefaults();
 
@@ -458,7 +457,7 @@ public interface IFernflowerPreferences {
     defaults.put(DUMP_TEXT_TOKENS, "0");
     defaults.put(REMOVE_IMPORTS, "0");
     defaults.put(MARK_CORRESPONDING_SYNTHETICS, "0");
-    defaults.put(EXCLUDED_CLASS_REGEX, "");
+    defaults.put(EXCLUDED_CLASSES, "");
 
     return Collections.unmodifiableMap(defaults);
   }

--- a/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java
+++ b/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java
@@ -382,6 +382,11 @@ public interface IFernflowerPreferences {
   @ShortName("mcs")
   String MARK_CORRESPONDING_SYNTHETICS = "mark-corresponding-synthetics";
 
+  @Name("Excluded Class Regex")
+  @Description("Exclude classes from decompilation if their fully qualified names match the specified regular expression.")
+  @ShortName("exc")
+  String EXCLUDED_CLASS_REGEX = "excluded-class-regex";
+
   Map<String, Object> DEFAULTS = getDefaults();
 
   static Map<String, Object> getDefaults() {
@@ -452,6 +457,7 @@ public interface IFernflowerPreferences {
     defaults.put(DUMP_TEXT_TOKENS, "0");
     defaults.put(REMOVE_IMPORTS, "0");
     defaults.put(MARK_CORRESPONDING_SYNTHETICS, "0");
+    defaults.put(EXCLUDED_CLASS_REGEX, "");
 
     return Collections.unmodifiableMap(defaults);
   }
@@ -475,7 +481,7 @@ public interface IFernflowerPreferences {
   public @interface Description {
     String value();
   }
-  
+
   @Retention(RetentionPolicy.RUNTIME)
   @Target(ElementType.FIELD)
   public @interface DynamicDefaultValue {
@@ -504,7 +510,7 @@ public interface IFernflowerPreferences {
   @Target(ElementType.FIELD)
   public @interface Type {
     String value();
-    
+
     String BOOLEAN = "bool";
     String INTEGER = "int";
     String STRING = "string";


### PR DESCRIPTION
Sometimes it's unnecessary to decompile certain classes, for example libraries such as Apache Commons. Skipping the decompilation of these classes can speed up the overall decompilation time. Currently there is `--only` option, but it doesn't cover cases where we don't know which classes in the JAR to decompile.

This PR adds that option to the decompiler (currently it's `--excluded-class-regex` or `-exc` for shorthand). It will skip the decompilation if the specified regex matches the fully qualified name of the class.

Examples:
```sh
# exclude all classes in org.apache package
java -jar vineflower.jar '-exc=org/apache/.*' input.jar out_dir

# exclude classes from multiple packages
java -jar vineflower.jar '-exc=org/(apache|bouncycastle)/.*|com/google/android/.*' input.jar out_dir
```