### PR TITLE
Simplify empty anonymous class bodies to `{}`

### DIFF
--- a/testData/results/pkg/TestAnonymousClassConstructor.dec
+++ b/testData/results/pkg/TestAnonymousClassConstructor.dec
@@ -2,63 +2,51 @@ package pkg;
 
 class TestAnonymousClassConstructor {
    void innerPrivateString() {
-      new TestAnonymousClassConstructor.InnerPrivateString("text") {// 5
-      };
+      new TestAnonymousClassConstructor.InnerPrivateString("text") {};// 5
    }// 6
 
    void innerPrivate() {
-      new TestAnonymousClassConstructor.InnerPrivate(3L, 4) {// 9
-      };
+      new TestAnonymousClassConstructor.InnerPrivate(3L, 4) {};// 9
    }// 10
 
    void innerStaticPrivateString() {
-      new TestAnonymousClassConstructor.InnerStaticPrivateString("text") {// 13
-      };
+      new TestAnonymousClassConstructor.InnerStaticPrivateString("text") {};// 13
    }// 14
 
    void innerStaticPrivate() {
-      new TestAnonymousClassConstructor.InnerStaticPrivate(3L, 4) {// 17
-      };
+      new TestAnonymousClassConstructor.InnerStaticPrivate(3L, 4) {};// 17
    }// 18
 
    static void innerStaticPrivateStringStatic() {
-      new TestAnonymousClassConstructor.InnerStaticPrivateString("text") {// 21
-      };
+      new TestAnonymousClassConstructor.InnerStaticPrivateString("text") {};// 21
    }// 22
 
    static void innerStaticPrivateStatic() {
-      new TestAnonymousClassConstructor.InnerStaticPrivate(3L, 4) {// 25
-      };
+      new TestAnonymousClassConstructor.InnerStaticPrivate(3L, 4) {};// 25
    }// 26
 
    void innerPublicString() {
-      new TestAnonymousClassConstructor.InnerPublicString("text") {// 29
-      };
+      new TestAnonymousClassConstructor.InnerPublicString("text") {};// 29
    }// 30
 
    void innerPublic() {
-      new TestAnonymousClassConstructor.InnerPublic(3L, 4) {// 33
-      };
+      new TestAnonymousClassConstructor.InnerPublic(3L, 4) {};// 33
    }// 34
 
    void innerStaticPublicString() {
-      new TestAnonymousClassConstructor.InnerStaticPublicString("text") {// 37
-      };
+      new TestAnonymousClassConstructor.InnerStaticPublicString("text") {};// 37
    }// 38
 
    void innerStaticPublic() {
-      new TestAnonymousClassConstructor.InnerStaticPublic(3L, 4) {// 41
-      };
+      new TestAnonymousClassConstructor.InnerStaticPublic(3L, 4) {};// 41
    }// 42
 
    static void innerStaticPublicStringStatic() {
-      new TestAnonymousClassConstructor.InnerStaticPublicString("text") {// 45
-      };
+      new TestAnonymousClassConstructor.InnerStaticPublicString("text") {};// 45
    }// 46
 
    static void innerStaticPublicStatic() {
-      new TestAnonymousClassConstructor.InnerStaticPublic(3L, 4) {// 49
-      };
+      new TestAnonymousClassConstructor.InnerStaticPublic(3L, 4) {};// 49
    }// 50
 
    static void n(String s) {
@@ -118,105 +106,132 @@ class 'pkg/TestAnonymousClassConstructor' {
    method 'innerPrivateString ()V' {
       5      4
       6      4
-      b      6
+      b      5
    }
 
    method 'innerPrivate ()V' {
-      5      9
-      6      9
-      7      9
-      8      9
-      d      11
+      5      8
+      6      8
+      7      8
+      8      8
+      d      9
    }
 
    method 'innerStaticPrivateString ()V' {
-      5      14
-      6      14
-      b      16
+      5      12
+      6      12
+      b      13
    }
 
    method 'innerStaticPrivate ()V' {
-      5      19
-      6      19
-      7      19
-      8      19
-      d      21
+      5      16
+      6      16
+      7      16
+      8      16
+      d      17
    }
 
    method 'innerStaticPrivateStringStatic ()V' {
-      4      24
-      5      24
-      a      26
+      4      20
+      5      20
+      a      21
    }
 
    method 'innerStaticPrivateStatic ()V' {
-      4      29
-      5      29
-      6      29
-      7      29
-      c      31
+      4      24
+      5      24
+      6      24
+      7      24
+      c      25
    }
 
    method 'innerPublicString ()V' {
-      5      34
-      6      34
-      b      36
+      5      28
+      6      28
+      b      29
    }
 
    method 'innerPublic ()V' {
-      5      39
-      6      39
-      7      39
-      8      39
-      d      41
+      5      32
+      6      32
+      7      32
+      8      32
+      d      33
    }
 
    method 'innerStaticPublicString ()V' {
-      5      44
-      6      44
-      b      46
+      5      36
+      6      36
+      b      37
    }
 
    method 'innerStaticPublic ()V' {
-      5      49
-      6      49
-      7      49
-      8      49
-      d      51
+      5      40
+      6      40
+      7      40
+      8      40
+      d      41
    }
 
    method 'innerStaticPublicStringStatic ()V' {
-      4      54
-      5      54
-      a      56
+      4      44
+      5      44
+      a      45
    }
 
    method 'innerStaticPublicStatic ()V' {
-      4      59
-      5      59
-      6      59
-      7      59
-      c      61
+      4      48
+      5      48
+      6      48
+      7      48
+      c      49
    }
 
    method 'n (Ljava/lang/String;)V' {
-      0      64
-      1      64
-      2      64
-      a      64
-      b      64
-      f      64
-      13      64
-      14      64
-      15      64
-      16      64
-      17      64
-      18      64
-      19      65
+      0      52
+      1      52
+      2      52
+      a      52
+      b      52
+      f      52
+      13      52
+      14      52
+      15      52
+      16      52
+      17      52
+      18      52
+      19      53
    }
 }
 
 class 'pkg/TestAnonymousClassConstructor$InnerPrivate' {
+   method '<init> (Lpkg/TestAnonymousClassConstructor;JI)V' {
+      10      57
+      14      57
+      15      57
+      19      57
+      1a      57
+      1e      57
+      1f      57
+      20      57
+      21      57
+      22      57
+      23      57
+      24      58
+   }
+}
+
+class 'pkg/TestAnonymousClassConstructor$InnerPrivateString' {
+   method '<init> (Lpkg/TestAnonymousClassConstructor;Ljava/lang/String;)V' {
+      9      63
+      a      63
+      b      63
+      c      63
+      d      64
+   }
+}
+
+class 'pkg/TestAnonymousClassConstructor$InnerPublic' {
    method '<init> (Lpkg/TestAnonymousClassConstructor;JI)V' {
       10      69
       14      69
@@ -233,7 +248,7 @@ class 'pkg/TestAnonymousClassConstructor$InnerPrivate' {
    }
 }
 
-class 'pkg/TestAnonymousClassConstructor$InnerPrivateString' {
+class 'pkg/TestAnonymousClassConstructor$InnerPublicString' {
    method '<init> (Lpkg/TestAnonymousClassConstructor;Ljava/lang/String;)V' {
       9      75
       a      75
@@ -243,34 +258,33 @@ class 'pkg/TestAnonymousClassConstructor$InnerPrivateString' {
    }
 }
 
-class 'pkg/TestAnonymousClassConstructor$InnerPublic' {
-   method '<init> (Lpkg/TestAnonymousClassConstructor;JI)V' {
+class 'pkg/TestAnonymousClassConstructor$InnerStaticPrivate' {
+   method '<init> (JI)V' {
+      b      81
+      f      81
       10      81
       14      81
-      15      81
+      18      81
       19      81
       1a      81
-      1e      81
-      1f      81
-      20      81
-      21      81
-      22      81
-      23      81
-      24      82
+      1b      81
+      1c      81
+      1d      81
+      1e      82
    }
 }
 
-class 'pkg/TestAnonymousClassConstructor$InnerPublicString' {
-   method '<init> (Lpkg/TestAnonymousClassConstructor;Ljava/lang/String;)V' {
-      9      87
-      a      87
-      b      87
-      c      87
-      d      88
+class 'pkg/TestAnonymousClassConstructor$InnerStaticPrivateString' {
+   method '<init> (Ljava/lang/String;)V' {
+      4      87
+      5      87
+      6      87
+      7      87
+      8      88
    }
 }
 
-class 'pkg/TestAnonymousClassConstructor$InnerStaticPrivate' {
+class 'pkg/TestAnonymousClassConstructor$InnerStaticPublic' {
    method '<init> (JI)V' {
       b      93
       f      93
@@ -286,7 +300,7 @@ class 'pkg/TestAnonymousClassConstructor$InnerStaticPrivate' {
    }
 }
 
-class 'pkg/TestAnonymousClassConstructor$InnerStaticPrivateString' {
+class 'pkg/TestAnonymousClassConstructor$InnerStaticPublicString' {
    method '<init> (Ljava/lang/String;)V' {
       4      99
       5      99
@@ -296,75 +310,49 @@ class 'pkg/TestAnonymousClassConstructor$InnerStaticPrivateString' {
    }
 }
 
-class 'pkg/TestAnonymousClassConstructor$InnerStaticPublic' {
-   method '<init> (JI)V' {
-      b      105
-      f      105
-      10      105
-      14      105
-      18      105
-      19      105
-      1a      105
-      1b      105
-      1c      105
-      1d      105
-      1e      106
-   }
-}
-
-class 'pkg/TestAnonymousClassConstructor$InnerStaticPublicString' {
-   method '<init> (Ljava/lang/String;)V' {
-      4      111
-      5      111
-      6      111
-      7      111
-      8      112
-   }
-}
-
 Lines mapping:
 5 <-> 5
-6 <-> 7
-9 <-> 10
-10 <-> 12
-13 <-> 15
-14 <-> 17
-17 <-> 20
-18 <-> 22
-21 <-> 25
-22 <-> 27
-25 <-> 30
-26 <-> 32
-29 <-> 35
-30 <-> 37
-33 <-> 40
-34 <-> 42
-37 <-> 45
-38 <-> 47
-41 <-> 50
-42 <-> 52
-45 <-> 55
-46 <-> 57
-49 <-> 60
-50 <-> 62
-53 <-> 65
-54 <-> 66
-58 <-> 76
-59 <-> 77
-64 <-> 70
-65 <-> 71
-70 <-> 100
-71 <-> 101
-76 <-> 94
-77 <-> 95
-82 <-> 88
-83 <-> 89
-88 <-> 82
-89 <-> 83
-94 <-> 112
-95 <-> 113
-100 <-> 106
-101 <-> 107
+6 <-> 6
+9 <-> 9
+10 <-> 10
+13 <-> 13
+14 <-> 14
+17 <-> 17
+18 <-> 18
+21 <-> 21
+22 <-> 22
+25 <-> 25
+26 <-> 26
+29 <-> 29
+30 <-> 30
+33 <-> 33
+34 <-> 34
+37 <-> 37
+38 <-> 38
+41 <-> 41
+42 <-> 42
+45 <-> 45
+46 <-> 46
+49 <-> 49
+50 <-> 50
+53 <-> 53
+54 <-> 54
+58 <-> 64
+59 <-> 65
+64 <-> 58
+65 <-> 59
+70 <-> 88
+71 <-> 89
+76 <-> 82
+77 <-> 83
+82 <-> 76
+83 <-> 77
+88 <-> 70
+89 <-> 71
+94 <-> 100
+95 <-> 101
+100 <-> 94
+101 <-> 95
 Not mapped:
 57
 63

--- a/testData/results/pkg/TestAnonymousClassNaming.dec
+++ b/testData/results/pkg/TestAnonymousClassNaming.dec
@@ -2,8 +2,7 @@ package pkg;
 
 public class TestAnonymousClassNaming {
    public void run(int i, final String s) throws Exception {
-      new Object() /* TestAnonymousClassNaming$1 */ {
-      };
+      new Object() /* TestAnonymousClassNaming$1 */ {};
       if (i < 0) {// 6
          throw new Exception() /* TestAnonymousClassNaming$2 */ {// 7
             public String getMessage() {
@@ -14,33 +13,32 @@ public class TestAnonymousClassNaming {
    }// 14
 
    private static class InnerClass {
-      Object o = new Object() /* TestAnonymousClassNaming$InnerClass$1 */ {
-      };
+      Object o = new Object() /* TestAnonymousClassNaming$InnerClass$1 */ {};
    }
 }
 
 class 'pkg/TestAnonymousClassNaming' {
    method 'run (ILjava/lang/String;)V' {
-      9      6
-      a      6
-      16      7
-      17      13
+      9      5
+      a      5
+      16      6
+      17      12
    }
 }
 
 class 'pkg/TestAnonymousClassNaming$2' {
    method 'getMessage ()Ljava/lang/String;' {
-      1      9
-      2      9
-      3      9
-      4      9
+      1      8
+      2      8
+      3      8
+      4      8
    }
 }
 
 Lines mapping:
-6 <-> 7
-7 <-> 8
-10 <-> 10
-14 <-> 14
+6 <-> 6
+7 <-> 7
+10 <-> 9
+14 <-> 13
 Not mapped:
 5

--- a/testData/results/pkg/TestAnonymousParamNames.dec
+++ b/testData/results/pkg/TestAnonymousParamNames.dec
@@ -1,8 +1,7 @@
 package pkg;
 
 public class TestAnonymousParamNames {
-   private final TestAnonymousParamNames.Clazz reference = new TestAnonymousParamNames.Clazz(0L, false) {
-   };
+   private final TestAnonymousParamNames.Clazz reference = new TestAnonymousParamNames.Clazz(0L, false) {};
 
    private class Clazz {
       public Clazz(long paramL, boolean paramB) {
@@ -12,11 +11,11 @@ public class TestAnonymousParamNames {
 
 class 'pkg/TestAnonymousParamNames$Clazz' {
    method '<init> (Lpkg/TestAnonymousParamNames;JZ)V' {
-      9      8
+      9      7
    }
 }
 
 Lines mapping:
-25 <-> 9
+25 <-> 8
 Not mapped:
 24

--- a/testData/results/pkg/TestDoubleNestedClass.dec
+++ b/testData/results/pkg/TestDoubleNestedClass.dec
@@ -20,8 +20,7 @@ public abstract class TestDoubleNestedClass {
    private static final TestDoubleNestedClass INNER2 = new TestDoubleNestedClass() {
       @Override
       Object test() {
-         return new Object() {
-         };
+         return new Object() {};
       }
    };
 
@@ -70,52 +69,52 @@ class 'pkg/TestDoubleNestedClass$2' {
 
 class 'pkg/TestDoubleNestedClass$Child1' {
    method 'foo (I)Ljava/util/function/Supplier;' {
-      0      33
-      1      33
-      2      33
-      b      34
+      0      32
+      1      32
+      2      32
+      b      33
    }
 
    method 'lambda$foo$0 (II)Lpkg/TestDoubleNestedClass;' {
-      a      34
+      a      33
    }
 }
 
 class 'pkg/TestDoubleNestedClass$Child1$1' {
    method 'test ()Ljava/lang/Object;' {
-      1      37
-      2      37
-      3      37
-      4      37
-      5      37
-      6      37
-      8      37
-      9      37
-      a      37
-      b      37
-      c      37
-      e      38
-      f      38
-      10      38
-      12      38
-      13      38
-      14      38
-      15      38
-      16      38
-      18      39
-      19      39
-      1a      39
-      1b      39
-      1c      39
-      1d      39
-      1e      39
-      1f      39
-      20      39
-      21      39
-      22      39
-      23      39
-      24      39
-      25      39
+      1      36
+      2      36
+      3      36
+      4      36
+      5      36
+      6      36
+      8      36
+      9      36
+      a      36
+      b      36
+      c      36
+      e      37
+      f      37
+      10      37
+      12      37
+      13      37
+      14      37
+      15      37
+      16      37
+      18      38
+      19      38
+      1a      38
+      1b      38
+      1c      38
+      1d      38
+      1e      38
+      1f      38
+      20      38
+      21      38
+      22      38
+      23      38
+      24      38
+      25      38
    }
 }
 


### PR DESCRIPTION
This is typically how people actually write code like this (as can be seen in the existing tests).

The improvement is extra noticeable with things like type tokens.

I can add an option for this if wanted. It would also not be hard to expand this to other types of classes, but that seemed less suitable, at least as a default behavior.