### PR TITLE
Fix indent on 'simple' switch branches

### DIFF
--- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/SwitchExprent.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/SwitchExprent.java
@@ -148,17 +148,17 @@ public class SwitchExprent extends Exprent {
             ((ConstExprent)content).setConstType(this.type);
           }
 
-          buf.append(content.toJava(indent).append(";"));
+          buf.append(content.toJava(indent + 1).append(";"));
         } else if (exprent instanceof ExitExprent) {
           ExitExprent exit = (ExitExprent) exprent;
 
           if (exit.getExitType() == ExitExprent.Type.THROW) {
-            buf.append(exit.toJava(indent).append(";"));
+            buf.append(exit.toJava(indent + 1).append(";"));
           } else {
             throw new IllegalStateException("Can't have return in switch expression");
           }
         } else { // Catchall
-          buf.append(exprent.toJava(indent).append(";"));
+          buf.append(exprent.toJava(indent + 1).append(";"));
         }
       } else {
         buf.append("{");

--- a/test/org/jetbrains/java/decompiler/SingleClassesTest.java
+++ b/test/org/jetbrains/java/decompiler/SingleClassesTest.java
@@ -697,6 +697,7 @@ public class SingleClassesTest extends SingleClassesTestBase {
     register(JAVA_8, "TestNumberDisambiguation");
     register(JAVA_8, "TestDanglingBoxingCall");
     register(JAVA_21, "TestSwitchOnEnumJ21", "ext/TestEnum2");
+    register(JAVA_21, "TestSwitchSimpleMultiLine");
     register(JAVA_21, "TestInnerClassesJ21");
     register(JAVA_21, "TestInnerClasses2J21");
     register(JAVA_21, "TestInnerClasses3J21");

--- a/testData/results/pkg/TestSwitchSimpleMultiLine.dec
+++ b/testData/results/pkg/TestSwitchSimpleMultiLine.dec
@@ -1,0 +1,74 @@
+package pkg;
+
+import java.util.Random;
+import java.util.function.Predicate;
+
+public class TestSwitchSimpleMultiLine {
+   public static <T> Predicate<T> predicates() {
+      int i = new Random().nextInt();// 8
+
+      return switch (i) {// 9
+         case 0 -> object -> true;// 10
+         case 1 -> object -> false;// 11
+         default -> object -> {
+            boolean r1 = new Random().nextBoolean();// 13
+            boolean r2 = new Random().nextBoolean();// 14
+            return r1 && r2 ? true : new Random().nextBoolean();// 15 16 18
+         };
+      };
+   }
+}
+
+class 'pkg/TestSwitchSimpleMultiLine' {
+   method 'predicates ()Ljava/util/function/Predicate;' {
+      7      7
+      8      7
+      9      7
+      a      7
+      b      9
+      c      9
+      3d      9
+   }
+
+   method 'lambda$predicates$0 (Ljava/lang/Object;)Z' {
+      0      10
+      1      10
+   }
+
+   method 'lambda$predicates$1 (Ljava/lang/Object;)Z' {
+      0      11
+      1      11
+   }
+
+   method 'lambda$predicates$2 (Ljava/lang/Object;)Z' {
+      7      13
+      8      13
+      9      13
+      a      13
+      12      14
+      13      14
+      14      14
+      15      14
+      16      15
+      17      15
+      1a      15
+      1b      15
+      1e      15
+      27      15
+      28      15
+      29      15
+   }
+}
+
+Lines mapping:
+8 <-> 8
+9 <-> 10
+10 <-> 11
+11 <-> 12
+13 <-> 14
+14 <-> 15
+15 <-> 16
+16 <-> 16
+18 <-> 16
+Not mapped:
+12

--- a/testData/src/java21/pkg/TestSwitchSimpleMultiLine.java
+++ b/testData/src/java21/pkg/TestSwitchSimpleMultiLine.java
@@ -1,0 +1,22 @@
+package pkg;
+
+import java.util.Random;
+import java.util.function.Predicate;
+
+public class TestSwitchSimpleMultiLine {
+  public static <T> Predicate<T> predicates() {
+    int i = new Random().nextInt();
+    return switch (i) {
+      case 0 -> object -> true;
+      case 1 -> object -> false;
+      default -> object -> {
+        final boolean r1 = new Random().nextBoolean();
+        final boolean r2 = new Random().nextBoolean();
+        if (r1 && r2) {
+          return true;
+        }
+        return new Random().nextBoolean();
+      };
+    };
+  }
+}


### PR DESCRIPTION
The test case would previously decompile to

```
public class TestSwitchSimpleMultiLine {
   public static <T> Predicate<T> predicates() {
      int i = new Random().nextInt();// 8

      return switch (i) {// 9
         case 0 -> object -> true;// 10
         case 1 -> object -> false;// 11
         default -> object -> {
         boolean r1 = new Random().nextBoolean();// 13
         boolean r2 = new Random().nextBoolean();// 14
         return r1 && r2 ? true : new Random().nextBoolean();// 15 16 18
      };
      };
   }
}
```