### PR TITLE
Add option to disable inner classes names validation

### DIFF
--- a/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java
+++ b/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java
@@ -176,7 +176,8 @@ public class ClassesProcessor implements CodeConstants {
               if (enclClassName == null || innerName.equals(enclClassName)) {
                 continue;  // invalid name or self reference
               }
-              if (rec.type == ClassNode.Type.MEMBER && !innerName.equals(enclClassName + '$' + entry.simpleName)) {
+              if (DecompilerContext.getOption(IFernflowerPreferences.VALIDATE_INNER_CLASSES_NAMES) &&
+                  rec.type == ClassNode.Type.MEMBER && !innerName.equals(enclClassName + '$' + entry.simpleName)) {
                 continue;  // not a real inner class
               }
 

--- a/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java
+++ b/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java
@@ -387,6 +387,11 @@ public interface IFernflowerPreferences {
   @Type(Type.STRING)
   String EXCLUDED_CLASSES = "excluded-classes";
 
+  @Name("Validate inner classes names")
+  @Description("Validates that the inner class name is correct (if it is separated using \"$\" for example BaseClass$InnerClass). If not then inner class won't be processed.")
+  @Type(Type.STRING)
+  String VALIDATE_INNER_CLASSES_NAMES = "validate-inner-classes-names";
+
   Map<String, Object> DEFAULTS = getDefaults();
 
   static Map<String, Object> getDefaults() {
@@ -458,6 +463,7 @@ public interface IFernflowerPreferences {
     defaults.put(REMOVE_IMPORTS, "0");
     defaults.put(MARK_CORRESPONDING_SYNTHETICS, "0");
     defaults.put(EXCLUDED_CLASSES, "");
+    defaults.put(VALIDATE_INNER_CLASSES_NAMES, "1");
 
     return Collections.unmodifiableMap(defaults);
   }


### PR DESCRIPTION
Added option to disable inner classes names validation. Useful when the jar that you are decompiling does not follow inner classes naming convention (i.e. does not have `$` in inner class names).