### PR TITLE
Fix stack size of first non synthetic parameter being used for synthetic parameters

### DIFF
--- a/src/org/jetbrains/java/decompiler/main/ClassWriter.java
+++ b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
@@ -1191,8 +1191,9 @@ public class ClassWriter implements StatementWriter {
 
         buffer.pushNewlineGroup(indent, 0);
         for (int i = start; i < md.params.length; i++) {
-          VarType parameterType = hasDescriptor && paramCount < descriptor.parameterTypes.size() ? descriptor.parameterTypes.get(paramCount) : md.params[i];
-          if (mask == null || mask.get(i) == null) {
+          boolean real = mask == null || mask.get(i) == null;
+          VarType parameterType = real && hasDescriptor && paramCount < descriptor.parameterTypes.size() ? descriptor.parameterTypes.get(paramCount) : md.params[i];
+          if (real) {
             if (paramCount > 0) {
               buffer.append(",");
               buffer.appendPossibleNewline(" ");

--- a/test/org/jetbrains/java/decompiler/SingleClassesTest.java
+++ b/test/org/jetbrains/java/decompiler/SingleClassesTest.java
@@ -702,6 +702,7 @@ public class SingleClassesTest extends SingleClassesTestBase {
     register(JAVA_21, "TestInnerClassesJ21");
     register(JAVA_21, "TestInnerClasses2J21");
     register(JAVA_21, "TestInnerClasses3J21");
+    register(JAVA_21, "TestInnerClasses4J21");
     register(JAVA_8, "TestInnerClassesJ8");
     register(JAVA_8, "TestSwitchInTry");
     register(JAVA_21, "TestSwitchPatternMatchingJ21");

--- a/testData/results/pkg/TestInnerClasses4J21.dec
+++ b/testData/results/pkg/TestInnerClasses4J21.dec
@@ -1,0 +1,21 @@
+package pkg;
+
+import java.util.List;
+
+public class TestInnerClasses4J21 {
+   private class Inner {
+      Inner(double d, List<Object> l) {
+      }// 9
+   }
+}
+
+class 'pkg/TestInnerClasses4J21$Inner' {
+   method '<init> (Lpkg/TestInnerClasses4J21;DLjava/util/List;)V' {
+      4      7
+   }
+}
+
+Lines mapping:
+9 <-> 8
+Not mapped:
+7

--- a/testData/src/java21/pkg/TestInnerClasses4J21.java
+++ b/testData/src/java21/pkg/TestInnerClasses4J21.java
@@ -1,0 +1,12 @@
+package pkg;
+
+import java.util.List;
+
+public class TestInnerClasses4J21 {
+  private class Inner {
+    Inner(double d, List<Object> l) {
+      
+    }
+  }
+    
+}


### PR DESCRIPTION
Fixes a case where it would always use the stack size of the first real parameter for synthetic parameters if the method has a signature