### PR TITLE
Fix local record classes that have the parent class as the first parameter

### DIFF
--- a/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
+++ b/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
@@ -333,7 +333,8 @@ public class NestedClassProcessor {
       if (nd.type != ClassNode.Type.LAMBDA &&
           !nd.classStruct.isSynthetic() &&
           (nd.access & CodeConstants.ACC_STATIC) == 0 &&
-          (nd.access & CodeConstants.ACC_INTERFACE) == 0) {
+          (nd.access & CodeConstants.ACC_INTERFACE) == 0 &&
+          nd.classStruct.getRecordComponents() == null) {
         clTypes.add(nd.type);
 
         Map<String, List<VarFieldPair>> mask = getMaskLocalVars(nd.getWrapper());

--- a/test/org/jetbrains/java/decompiler/SingleClassesTest.java
+++ b/test/org/jetbrains/java/decompiler/SingleClassesTest.java
@@ -708,6 +708,7 @@ public class SingleClassesTest extends SingleClassesTestBase {
     register(JAVA_8, "TestSwitchInTry");
     register(JAVA_21, "TestSwitchPatternMatchingJ21");
     register(JAVA_21, "TestCastIntersectionJ21");
+    register(JAVA_16, "TestRecordLocal");
   }
 
   private void registerEntireClassPath() {

--- a/testData/results/pkg/TestRecordLocal.dec
+++ b/testData/results/pkg/TestRecordLocal.dec
@@ -1,0 +1,23 @@
+package pkg;
+
+import java.util.List;
+
+public class TestRecordLocal {
+   public Object test(List<Integer> list) {
+      record Rec(TestRecordLocal a, List<Integer> b) {
+      }
+
+      return new Rec(this, list);// 9
+   }
+}
+
+class 'pkg/TestRecordLocal' {
+   method 'test (Ljava/util/List;)Ljava/lang/Object;' {
+      4      9
+      5      9
+      9      9
+   }
+}
+
+Lines mapping:
+9 <-> 10

--- a/testData/src/java16/pkg/TestRecordLocal.java
+++ b/testData/src/java16/pkg/TestRecordLocal.java
@@ -1,0 +1,11 @@
+package pkg;
+
+import java.util.List;
+
+public class TestRecordLocal {
+    public Object test(List<Integer> list) {
+        record Rec(TestRecordLocal a, List<Integer> b) {}
+  
+        return new Rec(this, list);
+    }
+}


### PR DESCRIPTION
Fixes #413 

https://docs.oracle.com/javase/specs/jls/se16/html/jls-8.html#jls-8.10
> A nested record class is implicitly static.