### PR TITLE
Mark config item `mcs` as a bool

### DIFF
--- a/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java
+++ b/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java
@@ -380,6 +380,7 @@ public interface IFernflowerPreferences {
   @Name("Mark Corresponding Synthetics")
   @Description("Mark lambdas and anonymous and local classes with their respective synthetic constructs")
   @ShortName("mcs")
+  @Type(Type.BOOLEAN)
   String MARK_CORRESPONDING_SYNTHETICS = "mark-corresponding-synthetics";
 
   Map<String, Object> DEFAULTS = getDefaults();


### PR DESCRIPTION
Mark config item `mcs` as a bool
Currently it lacks a type annotation and is ignored by `writeOptions`.
