### PR TITLE
Add test for Expression Optimization Issue

### DIFF
--- a/test/org/jetbrains/java/decompiler/SingleClassesTest.java
+++ b/test/org/jetbrains/java/decompiler/SingleClassesTest.java
@@ -711,6 +711,8 @@ public class SingleClassesTest extends SingleClassesTestBase {
     // TODO: broken stack processing, deleted ternary!
     register(JAVA_17, "TestPatternMatchingLoops");
     register(JAVA_8, "TestBoxingSuperclass");
+    // TODO: shouldBeOne is completely deleted
+    register(JAVA_8, "TestLVTReassignment");
   }
 
   private void registerEntireClassPath() {

--- a/testData/results/pkg/TestLVTReassignment.dec
+++ b/testData/results/pkg/TestLVTReassignment.dec
@@ -1,0 +1,50 @@
+package pkg;
+
+public class TestLVTReassignment {
+   public void test() {
+      double one = 1.0;// 5
+      one = 0.0;// 7
+      if (one > 1.0) {// 8
+      }
+
+      this.blackhole(one);// 6 11
+   }// 12
+
+   void blackhole(double value) {
+   }// 16
+}
+
+class 'pkg/TestLVTReassignment' {
+   method 'test ()V' {
+      0      4
+      1      4
+      2      9
+      4      5
+      5      5
+      6      6
+      7      6
+      8      6
+      9      6
+      a      6
+      b      6
+      c      9
+      d      9
+      e      9
+      f      9
+      10      9
+      11      10
+   }
+
+   method 'blackhole (D)V' {
+      0      13
+   }
+}
+
+Lines mapping:
+5 <-> 5
+6 <-> 10
+7 <-> 6
+8 <-> 7
+11 <-> 10
+12 <-> 11
+16 <-> 14

--- a/testData/src/java8/pkg/TestLVTReassignment.java
+++ b/testData/src/java8/pkg/TestLVTReassignment.java
@@ -1,0 +1,17 @@
+package pkg;
+
+public class TestLVTReassignment {
+  public void test() {
+    double one = 1;
+    double shouldBeOne = one;
+    one = 0;
+    if (one > 1) {
+    }
+
+    blackhole(shouldBeOne);
+  }
+
+  void blackhole(double value) {
+
+  }
+}


### PR DESCRIPTION
This includes a test for a strange issue that causes LVT reassignments to be lost. 

## Source:
```java
double one = 1;
double shouldBeOne = one;
one = 0;
if (one > 1) {
}

System.out.println(shouldBeOne); // -> 1.0
```

## Decompiles to:
```java
double one = 1.0;
one = 0.0;
if (one > 1.0) {
}

System.out.println(one); // -> 0.0
```

### Odd Case
It should be noted that without the if statement, it appears to work fine.
```
// Decompiles to without if statement
double one = 1.0;
double var5 = 0.0; // <- although interestingly, this LVT name is lost
System.out.println(one);
```