### PR TITLE
Prevent NPE on #getRecordComponents for Object

### DIFF
--- a/src/org/jetbrains/java/decompiler/struct/StructClass.java
+++ b/src/org/jetbrains/java/decompiler/struct/StructClass.java
@@ -213,7 +213,7 @@ public class StructClass extends StructMember {
     if (recordAttr == null) {
       // If our class extends j.l.Record but also has no components, it's probably malformed.
       // Force processing as a record anyway, in the hopes that we can come to a better result.
-      if (this.superClass.getString().equals("java/lang/Record")) {
+      if (this.superClass != null && this.superClass.getString().equals("java/lang/Record")) {
         return new ArrayList<>();
       }
 


### PR DESCRIPTION
Requesting the record components from a struct class has a fallback to
an empty list over null for objects that extend j.l.Record but do not
have a record attribute.

This fallback however assumes that the type has a superclass, which is
not the case for j.l.Object, causing a NPE.
