### PR TITLE
Get children methods for vararg calls

### DIFF
--- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
@@ -1177,6 +1177,9 @@ public class InvocationExprent extends Exprent {
     StructClass cl = DecompilerContext.getStructContext().getClass(classname);
     if (cl != null) {
       StructMethod mt = cl.getMethod(InterpreterUtil.makeUniqueKey(name, stringDescriptor));
+      if (mt == null) {
+        mt = cl.getMethodRecursive(name, stringDescriptor);
+      }
       if (mt != null) {
         return mt.hasModifier(CodeConstants.ACC_VARARGS);
       }

--- a/testData/results/pkg/TestVarArgCalls.dec
+++ b/testData/results/pkg/TestVarArgCalls.dec
@@ -23,6 +23,22 @@ public class TestVarArgCalls {
    public void printComplex(String fmt, String[]... params) {
       System.out.println(String.format(fmt, (Object[])params));// 27
    }// 28
+
+   public class Parent {
+      protected void test(TestVarArgCalls.Test... test) {
+      }// 33
+
+      class Child extends TestVarArgCalls.Parent {
+         public void vararg() {
+            this.test(TestVarArgCalls.Test.A, TestVarArgCalls.Test.B);// 38
+         }// 39
+      }
+   }
+
+   public static enum Test {
+      A,
+      B;
+   }
 }
 
 class 'pkg/TestVarArgCalls' {
@@ -160,6 +176,28 @@ class 'pkg/TestVarArgCalls' {
    }
 }
 
+class 'pkg/TestVarArgCalls$Parent' {
+   method 'test ([Lpkg/TestVarArgCalls$Test;)V' {
+      0      28
+   }
+}
+
+class 'pkg/TestVarArgCalls$Parent$Child' {
+   method 'vararg ()V' {
+      0      32
+      7      32
+      8      32
+      9      32
+      d      32
+      e      32
+      f      32
+      11      32
+      12      32
+      13      32
+      14      33
+   }
+}
+
 Lines mapping:
 5 <-> 5
 6 <-> 6
@@ -178,3 +216,6 @@ Lines mapping:
 24 <-> 21
 27 <-> 24
 28 <-> 25
+33 <-> 29
+38 <-> 33
+39 <-> 34

--- a/testData/src/java8/pkg/TestVarArgCalls.java
+++ b/testData/src/java8/pkg/TestVarArgCalls.java
@@ -26,4 +26,23 @@ public class TestVarArgCalls {
   public void printComplex(String fmt, String[]... params) {
     System.out.println(String.format(fmt, (Object[]) params));
   }
+
+  public class Parent {
+    protected void test(Test... test) {
+
+    }
+
+    class Child extends Parent {
+
+      public void vararg() {
+        test(Test.A, Test.B);
+      }
+
+    }
+  }
+
+  public enum Test {
+    A,
+    B
+  }
 }


### PR DESCRIPTION
Fixes parent class lookups for varargs not working.
[Minecraft diff](https://pastes.dev/gwgpYReemF)