### PR TITLE
Feature/better multi entry exception deobf

### DIFF
--- a/src/org/jetbrains/java/decompiler/code/Instruction.java
+++ b/src/org/jetbrains/java/decompiler/code/Instruction.java
@@ -2,7 +2,6 @@
 package org.jetbrains.java.decompiler.code;
 
 import org.jetbrains.java.decompiler.util.TextUtil;
-import static org.jetbrains.java.decompiler.code.CodeConstants.*;
 
 public class Instruction implements CodeConstants {
   public static Instruction create(
@@ -78,6 +77,21 @@ public class Instruction implements CodeConstants {
            !(opcode >= opc_ireturn && opcode <= opc_return) &&
            opcode != opc_athrow &&
            opcode != opc_jsr && opcode != opc_tableswitch && opcode != opc_lookupswitch;
+  }
+
+  public boolean canNotThrow() {
+    // Ignoring VirtualMachineErrors, including link errors
+    return opcode <= opc_sipush ||
+      (opc_iload <= opcode && opcode <= opc_aload_3) ||
+      (opc_istore <= opcode && opcode <= opc_astore_3) ||
+      (opc_pop <= opcode && opcode <= opc_dmul) ||
+      (opcode == opc_fdiv) ||
+      (opcode == opc_ddiv) ||
+      (opcode == opc_frem) ||
+      (opcode == opc_drem) ||
+      (opc_ineg <= opcode && opcode <= opc_lookupswitch) ||
+      (opcode == opc_wide) ||
+      (opc_ifnull <= opcode && opcode <= opc_jsr_w);
   }
 
   @Override

--- a/src/org/jetbrains/java/decompiler/code/cfg/BasicBlock.java
+++ b/src/org/jetbrains/java/decompiler/code/cfg/BasicBlock.java
@@ -174,7 +174,7 @@ public class BasicBlock implements IGraphNode {
   }
 
   @Override
-  public Collection<? extends IGraphNode> getPredecessors() {
+  public Collection<? extends BasicBlock> getPredecessors() {
     List<BasicBlock> lst = new ArrayList<>(preds);
     lst.addAll(predExceptions);
     return lst;

--- a/src/org/jetbrains/java/decompiler/code/cfg/ControlFlowGraph.java
+++ b/src/org/jetbrains/java/decompiler/code/cfg/ControlFlowGraph.java
@@ -153,19 +153,28 @@ public class ControlFlowGraph implements CodeConstants {
   }
 
   public ExceptionRangeCFG getExceptionRange(BasicBlock handler, BasicBlock block) {
-
-    //List<ExceptionRangeCFG> ranges = new ArrayList<ExceptionRangeCFG>();
-
     for (int i = exceptions.size() - 1; i >= 0; i--) {
       ExceptionRangeCFG range = exceptions.get(i);
       if (range.getHandler() == handler && range.getProtectedRange().contains(block)) {
         return range;
-        //ranges.add(range);
       }
     }
 
     return null;
-    //return ranges.isEmpty() ? null : ranges;
+  }
+
+  public List<ExceptionRangeCFG> getAllExceptionRanges(BasicBlock handler, BasicBlock block) {
+
+    List<ExceptionRangeCFG> ranges = new ArrayList<>();
+
+    for (int i = exceptions.size() - 1; i >= 0; i--) {
+      ExceptionRangeCFG range = exceptions.get(i);
+      if (range.getHandler() == handler && range.getProtectedRange().contains(block)) {
+        ranges.add(range);
+      }
+    }
+
+    return ranges;
   }
 
   //	public String getExceptionsUniqueString(BasicBlock handler, BasicBlock block) {

--- a/src/org/jetbrains/java/decompiler/modules/code/ExceptionDeobfuscator.java
+++ b/src/org/jetbrains/java/decompiler/modules/code/ExceptionDeobfuscator.java
@@ -336,6 +336,7 @@ public final class ExceptionDeobfuscator {
       boolean splitted = false;
 
       for (ExceptionRangeCFG range : graph.getExceptions()) {
+        // map of entry points to entry sources (null indicating method start)
         LinkedHashMap<BasicBlock, List<@Nullable BasicBlock>> setEntries = getRangeEntries(range, graph.getFirst());
 
         if (setEntries.size() > 1) { // multiple-entry protected range
@@ -386,6 +387,7 @@ public final class ExceptionDeobfuscator {
   ) {
     // Try to inline basic blocks that can't throw, but are only reachable from within this handler
     //  and have successors in this handler
+    // Each try handler must have at least one entry point that can't be removed
     @Nullable BasicBlock missed = null;
 
     for(var entry : setEntries.entrySet()) {
@@ -398,6 +400,8 @@ public final class ExceptionDeobfuscator {
         return false; // At least 2 entry points exist that can't be fixed
       }
     }
+
+    ValidationHelper.notNull(missed);
 
     // inlining time;
     Set<BasicBlock> handled = new HashSet<>();

--- a/src/org/jetbrains/java/decompiler/modules/code/ExceptionDeobfuscator.java
+++ b/src/org/jetbrains/java/decompiler/modules/code/ExceptionDeobfuscator.java
@@ -1,6 +1,7 @@
 // Copyright 2000-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package org.jetbrains.java.decompiler.modules.code;
 
+import org.jetbrains.annotations.Nullable;
 import org.jetbrains.java.decompiler.code.*;
 import org.jetbrains.java.decompiler.code.cfg.BasicBlock;
 import org.jetbrains.java.decompiler.code.cfg.ControlFlowGraph;
@@ -8,6 +9,7 @@ import org.jetbrains.java.decompiler.code.cfg.ExceptionRangeCFG;
 import org.jetbrains.java.decompiler.main.DecompilerContext;
 import org.jetbrains.java.decompiler.main.extern.IFernflowerLogger;
 import org.jetbrains.java.decompiler.main.extern.IFernflowerPreferences;
+import org.jetbrains.java.decompiler.modules.decompiler.ValidationHelper;
 import org.jetbrains.java.decompiler.modules.decompiler.decompose.GenericDominatorEngine;
 import org.jetbrains.java.decompiler.modules.decompiler.decompose.IGraph;
 import org.jetbrains.java.decompiler.modules.decompiler.decompose.IGraphNode;
@@ -334,12 +336,16 @@ public final class ExceptionDeobfuscator {
       boolean splitted = false;
 
       for (ExceptionRangeCFG range : graph.getExceptions()) {
-        Set<BasicBlock> setEntries = getRangeEntries(range, graph.getFirst());
+        LinkedHashMap<BasicBlock, List<@Nullable BasicBlock>> setEntries = getRangeEntries(range, graph.getFirst());
 
         if (setEntries.size() > 1) { // multiple-entry protected range
           found = true;
 
-          if (splitExceptionRange(range, setEntries, graph, engine)) {
+          if (growExceptionRange(range, setEntries)) {
+            splitted = true;
+            graph.addComment("$VF: Handled exception range with multiple entry points by growing it");
+            break;
+          } else if (splitExceptionRange(range, setEntries.keySet(), graph, engine)) {
             splitted = true;
             graph.addComment("$VF: Handled exception range with multiple entry points by splitting it");
             break;
@@ -355,26 +361,91 @@ public final class ExceptionDeobfuscator {
     return !found;
   }
 
-  private static Set<BasicBlock> getRangeEntries(ExceptionRangeCFG range, BasicBlock first) {
-    Set<BasicBlock> setEntries = new HashSet<>();
+  private static LinkedHashMap<BasicBlock, List<@Nullable BasicBlock>> getRangeEntries(ExceptionRangeCFG range, BasicBlock first) {
+    LinkedHashMap<BasicBlock, List<@Nullable BasicBlock>> setEntries = new LinkedHashMap<>();
     Set<BasicBlock> setRange = new HashSet<>(range.getProtectedRange());
 
     for (BasicBlock block : range.getProtectedRange()) {
+      List<@Nullable BasicBlock> setPreds = new ArrayList<>(block.getPreds());
+      setPreds.removeAll(setRange);
       if (block == first){
-        setEntries.add(block);
-        continue;
+        setPreds.add(null);
       }
 
-      Set<BasicBlock> setPreds = new HashSet<>(block.getPreds());
-      setPreds.removeAll(setRange);
-
       if (!setPreds.isEmpty()) {
-        setEntries.add(block);
+        setEntries.put(block, setPreds);
       }
     }
 
     return setEntries;
   }
+
+  private static boolean growExceptionRange(
+    ExceptionRangeCFG range,
+    LinkedHashMap<BasicBlock, List<@Nullable BasicBlock>> setEntries
+  ) {
+    // Try to inline basic blocks that can't throw, but are only reachable from within this handler
+    //  and have successors in this handler
+    @Nullable BasicBlock missed = null;
+
+    for(var entry : setEntries.entrySet()) {
+      BasicBlock destination = entry.getKey();
+      if (!validateExceptionGrow(range, entry.getValue())){
+        if (missed == null) {
+          missed = destination;
+          continue;
+        }
+        return false; // At least 2 entry points exist that can't be fixed
+      }
+    }
+
+    // inlining time;
+    Set<BasicBlock> handled = new HashSet<>();
+    for(var entry : setEntries.entrySet()) {
+      if (missed == entry.getKey()) {
+        continue;
+      }
+      for (BasicBlock block : entry.getValue()) {
+        ValidationHelper.notNull(block);
+        if (!handled.add(block)) { // prevent handling twice
+          continue;
+        }
+        block.addSuccessorException(range.getHandler());
+        range.getProtectedRange().add(block);
+      }
+    }
+    return true;
+  }
+
+  private static boolean validateExceptionGrow(
+    ExceptionRangeCFG range,
+    List<@Nullable BasicBlock> blocks
+  ){
+    Set<BasicBlock> protectedRange = new HashSet<>(range.getProtectedRange());
+    for (BasicBlock block : blocks) {
+      // can't optimize away method entry
+      if (block == null) {
+        return false;
+      }
+
+      if(!protectedRange.containsAll(block.getPredecessors())) {
+          // limit to inlining single blocks, not sequences of blocks
+          return false;
+      }
+
+      for (Instruction inst:block.getSeq()){
+        if (!inst.canNotThrow()) {
+          // We don't want to catch extra exceptions
+          //  many instructions can only throw a very small number of exceptions
+          //  so we could actually filter more lenient based on the caught exception types
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+
 
   private static boolean splitExceptionRange(ExceptionRangeCFG range,
                                              Set<BasicBlock> setEntries,

--- a/src/org/jetbrains/java/decompiler/modules/code/ExceptionDeobfuscator.java
+++ b/src/org/jetbrains/java/decompiler/modules/code/ExceptionDeobfuscator.java
@@ -403,7 +403,7 @@ public final class ExceptionDeobfuscator {
 
     ValidationHelper.notNull(missed);
 
-    // inlining time;
+    // Cleanup is possible. Add blocks to exception range.
     Set<BasicBlock> handled = new HashSet<>();
     for(var entry : setEntries.entrySet()) {
       if (missed == entry.getKey()) {

--- a/src/org/jetbrains/java/decompiler/modules/code/ExceptionDeobfuscator.java
+++ b/src/org/jetbrains/java/decompiler/modules/code/ExceptionDeobfuscator.java
@@ -344,7 +344,7 @@ public final class ExceptionDeobfuscator {
 
           if (growExceptionRange(range, setEntries)) {
             splitted = true;
-            graph.addComment("$VF: Handled exception range with multiple entry points by growing it");
+            graph.addComment("$VF: Handled exception range with multiple entry points by expanding it");
             break;
           } else if (splitExceptionRange(range, setEntries.keySet(), graph, engine)) {
             splitted = true;

--- a/testData/results/pkg/TestTryCatchNoIncrement.dec
+++ b/testData/results/pkg/TestTryCatchNoIncrement.dec
@@ -14,33 +14,17 @@ public class TestTryCatchNoIncrement {
       }
    }// 20
 
-   // $VF: Handled exception range with multiple entry points by splitting it
-   // $VF: Duplicated exception handlers to handle obfuscated exceptions
+   // $VF: Handled exception range with multiple entry points by growing it
    public final void skippedInc(List<String> items) {
-      int i;
       try {
-         i = 0;// 24
-      } catch (Throwable ex2) {
-         ex2.printStackTrace();// 35
-         return;// 38
-      }
-
-      while (true) {
-         try {
-            if (i >= items.size()) {// 25
-               break;
-            }
-
+         for (int i = 0; i < items.size(); i++) {// 24 25 29
             String item = (String)items.get(i);// 26
             System.out.println(i + ": " + item);// 27
-         } catch (Throwable ex2) {
-            ex2.printStackTrace();
-            break;
          }
-
-         i++;// 29
+      } catch (Throwable ex2) {// 34
+         ex2.printStackTrace();// 35
       }
-   }
+   }// 38
 
    // $VF: Handled exception range with multiple entry points by splitting it
    // $VF: Duplicated exception handlers to handle obfuscated exceptions
@@ -128,97 +112,98 @@ class 'pkg/TestTryCatchNoIncrement' {
    }
 
    method 'skippedInc (Ljava/util/List;)V' {
-      0      21
-      1      21
-      2      29
-      3      29
-      4      29
-      5      29
-      6      29
-      7      29
-      8      29
-      9      29
-      a      29
-      b      29
-      c      33
-      d      33
-      e      33
-      f      33
-      10      33
-      11      33
-      12      33
-      13      33
-      14      33
-      15      33
-      16      33
-      17      34
-      18      34
-      19      34
-      21      34
-      25      34
-      26      34
-      2a      34
-      2e      34
-      2f      34
-      30      34
-      31      34
-      32      34
-      33      34
-      34      40
-      35      40
-      36      40
-      43      23
-      44      23
-      45      23
-      46      23
-      47      24
+      0      19
+      1      19
+      2      19
+      3      19
+      4      19
+      5      19
+      6      19
+      7      19
+      8      19
+      9      19
+      a      19
+      b      19
+      c      20
+      d      20
+      e      20
+      f      20
+      10      20
+      11      20
+      12      20
+      13      20
+      14      20
+      15      20
+      16      20
+      17      21
+      18      21
+      19      21
+      21      21
+      25      21
+      26      21
+      2a      21
+      2e      21
+      2f      21
+      30      21
+      31      21
+      32      21
+      33      21
+      34      19
+      35      19
+      36      19
+      42      23
+      43      24
+      44      24
+      45      24
+      46      24
+      47      26
    }
 
    method 'skipPrinting (Ljava/util/List;)V' {
-      0      49
-      1      49
-      2      58
-      3      58
-      4      58
-      5      58
-      6      58
-      7      58
-      8      58
-      9      58
-      a      58
-      b      58
-      c      62
-      d      62
-      e      62
-      f      62
-      10      62
-      11      62
-      12      62
-      13      62
-      14      62
-      15      62
-      16      62
-      17      68
-      18      68
-      19      68
-      21      68
-      25      68
-      26      68
-      2a      68
-      2e      68
-      2f      68
-      30      68
-      31      68
-      32      68
-      33      68
-      39      71
-      3a      71
-      3b      71
-      43      51
-      44      51
-      45      51
-      46      51
-      47      52
+      0      33
+      1      33
+      2      42
+      3      42
+      4      42
+      5      42
+      6      42
+      7      42
+      8      42
+      9      42
+      a      42
+      b      42
+      c      46
+      d      46
+      e      46
+      f      46
+      10      46
+      11      46
+      12      46
+      13      46
+      14      46
+      15      46
+      16      46
+      17      52
+      18      52
+      19      52
+      21      52
+      25      52
+      26      52
+      2a      52
+      2e      52
+      2f      52
+      30      52
+      31      52
+      32      52
+      33      52
+      39      55
+      3a      55
+      3b      55
+      43      35
+      44      35
+      45      35
+      46      35
+      47      36
    }
 }
 
@@ -229,24 +214,24 @@ Lines mapping:
 17 <-> 12
 18 <-> 13
 20 <-> 15
-24 <-> 22
-25 <-> 30
-26 <-> 34
-27 <-> 35
-29 <-> 41
-35 <-> 24
-38 <-> 25
-41 <-> 72
-42 <-> 63
-44 <-> 69
-50 <-> 52
-52 <-> 53
+24 <-> 20
+25 <-> 20
+26 <-> 21
+27 <-> 22
+29 <-> 20
+34 <-> 24
+35 <-> 25
+38 <-> 27
+41 <-> 56
+42 <-> 47
+44 <-> 53
+50 <-> 36
+52 <-> 37
 Not mapped:
 19
 30
 31
 32
-34
 36
 45
 46

--- a/testData/results/pkg/TestTryCatchNoIncrement.dec
+++ b/testData/results/pkg/TestTryCatchNoIncrement.dec
@@ -14,7 +14,7 @@ public class TestTryCatchNoIncrement {
       }
    }// 20
 
-   // $VF: Handled exception range with multiple entry points by growing it
+   // $VF: Handled exception range with multiple entry points by expanding it
    public final void skippedInc(List<String> items) {
       try {
          for (int i = 0; i < items.size(); i++) {// 24 25 29


### PR DESCRIPTION
Improves the decompilation of some outputs by adding basic blocks that can't throw to a catch handler instead of having the catch handler get split.