### PR TITLE
Kotlin: guard array-dim access in KNewExprent for type-promoted empty arrays

### DIFF
--- a/plugins/kotlin/src/main/java/org/vineflower/kotlin/expr/KNewExprent.java
+++ b/plugins/kotlin/src/main/java/org/vineflower/kotlin/expr/KNewExprent.java
@@ -229,14 +229,23 @@ public class KNewExprent extends NewExprent implements KExprent {
       buf.popNewlineGroup();
       buf.append(']');
     } else if (getLstArrayElements().isEmpty()) {
-      //TODO there should never be a multi-dimension new array created here - check if the handling is necessary
+      // The JVM `anewarray`/`multianewarray` opcodes only push as many sizes as
+      // dimensions actually allocated. When the receiver type was promoted to a
+      // higher rank (e.g. by a checkcast on the result), `getNewType().arrayDim`
+      // can exceed `getLstDims().size()`. Mirror NewExprent's `i < lstDims.size()`
+      // guard: emit the size for the dims we have, and `0` for the rest.
+      int sizedDims = Math.min(getLstDims().size(), getNewType().arrayDim);
       for (int i = 0; i < getNewType().arrayDim - 1; i++) {
         buf.append("Array(");
-        Exprent dim = getLstDims().get(i);
-        if (dim.type == Type.CONST) {
-          ((ConstExprent) dim).adjustConstType(VarType.VARTYPE_INT);
+        if (i < sizedDims) {
+          Exprent dim = getLstDims().get(i);
+          if (dim.type == Type.CONST) {
+            ((ConstExprent) dim).adjustConstType(VarType.VARTYPE_INT);
+          }
+          buf.append(dim.toJava(indent));
+        } else {
+          buf.append('0');
         }
-        buf.append(dim.toJava(indent));
         buf.append(") {");
         buf.pushNewlineGroup(indent, 1);
         buf.appendPossibleNewline(" ");
@@ -254,11 +263,17 @@ public class KNewExprent extends NewExprent implements KExprent {
         default -> "arrayOfNulls";
       }).append('(');
 
-      Exprent dim = getLstDims().get(getNewType().arrayDim - 1);
-      if (dim.type == Type.CONST) {
-        ((ConstExprent) dim).adjustConstType(VarType.VARTYPE_INT);
+      int innerIdx = getNewType().arrayDim - 1;
+      if (innerIdx < sizedDims) {
+        Exprent dim = getLstDims().get(innerIdx);
+        if (dim.type == Type.CONST) {
+          ((ConstExprent) dim).adjustConstType(VarType.VARTYPE_INT);
+        }
+        buf.append(dim.toJava(indent));
+      } else {
+        buf.append('0');
       }
-      buf.append(dim.toJava(indent)).append(')');
+      buf.append(')');
 
       for (int i = 0; i < getNewType().arrayDim - 1; i++) {
         buf.appendPossibleNewline(" ", true);


### PR DESCRIPTION
## Describe the bug

`KNewExprent.toJava` at line 257 (1.12.0; identical on `develop/1.13.0`) throws `IndexOutOfBoundsException` whenever a JVM `anewarray` produces a single-dim array but the receiver type was promoted to a higher array rank by a subsequent `checkcast`. The empty-elements path indexes `getLstDims().get(getNewType().arrayDim - 1)` blindly, even though `getLstDims().size()` only contains the dims that the bytecode actually allocated.

### Minimal repro

```kotlin
fun colorStateListOf(vararg mapping: Pair<IntArray, Int>): ColorStateList {
  val (states, colors) = mapping.unzip()
  return ColorStateList(states.toTypedArray(), colors.toIntArray())
}
```

`states.toTypedArray()` compiles to `Collection.toArray(new IntArray[0])` whose result is `checkcast`ed to `[[I`, so the `NewExprent` for the `new IntArray[0]` has `arrayDim=2` and `lstDims.size()=1`.

### Stack trace (from a real Android app jar)

```
java.lang.IndexOutOfBoundsException: Index 1 out of bounds for length 1
  at java.base/java.util.ArrayList.get(ArrayList.java:428)
  at org.vineflower.kotlin.expr.KNewExprent.toJava(KNewExprent.java:257)
  at org.jetbrains.java.decompiler.modules.decompiler.ExprProcessor.getCastedExprent(ExprProcessor.java:1054)
  at org.jetbrains.java.decompiler.modules.decompiler.exps.InvocationExprent.appendParamList(InvocationExprent.java:1151)
  at org.jetbrains.java.decompiler.modules.decompiler.exps.InvocationExprent.toJava(InvocationExprent.java:921)
```

## Describe the fix

Mirror the existing `i < lstDims.size()` guard that the non-Kotlin `NewExprent.java:497` already uses on the same data. Emit the available dimension size for the dims `lstDims` actually contains, and `0` for any further dims that the type promotion implied. Output for the repro case becomes `Array(0) { IntArray(0) }` — semantically correct for an empty `Array<IntArray>` (the JVM `[[I` shape).

## Provenance disclosure

I diagnosed and authored this patch while pair-coding with Claude (Anthropic's coding agent) inside a focused diagnose-loop session against a real-world Android APK. I have personally read, understood, validated, and signed off on the change. Flagging this because of the AI-tools checkbox on the bugfix template — happy to discuss further, rewrite/refactor in whatever style you'd prefer, or close this and re-file as an issue with a reduced bytecode repro if you'd rather not accept AI-assisted PRs at all.

## Checklist
- [x] This PR targets the latest `develop/` branch (`develop/1.13.0`).
- [ ] Unit tests were added or modified to validate this change. *(Existing Kotlin test suite passes; I did not add a new fixture — happy to write one if you'd like a minimal reproducer added to `plugins/kotlin/testData/`.)*
- [ ] No AI tools were used in making this change. *(See provenance disclosure above.)*