### PR TITLE
FinallyProcessor: guard instrOldOffsets removals when out of sync with seq

### DIFF
--- a/src/org/jetbrains/java/decompiler/modules/decompiler/FinallyProcessor.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/FinallyProcessor.java
@@ -1049,25 +1049,35 @@ public class FinallyProcessor {
     if (finallytype == 3) { // empty finally handler
       for (int i = seq.length() - 1; i >= 0; i--) {
         seq.removeInstruction(i);
-        instrOldOffsets.remove(i);
+        if (i < instrOldOffsets.size()) {
+          instrOldOffsets.remove(i);
+        }
       }
     } else {
       if ((blocktype & 1) > 0) { // first
         if (finallytype == 2 || finallytype == 1) { // astore or pop
-          seq.removeInstruction(0);
-          instrOldOffsets.remove(0);
+          if (!seq.isEmpty()) {
+            seq.removeInstruction(0);
+          }
+          if (!instrOldOffsets.isEmpty()) {
+            instrOldOffsets.remove(0);
+          }
         }
       }
 
       if ((blocktype & 2) > 0) { // last
         if (finallytype == 2 || finallytype == 0) {
           seq.removeLast();
-          instrOldOffsets.remove(instrOldOffsets.size() - 1);
+          if (!instrOldOffsets.isEmpty()) {
+            instrOldOffsets.remove(instrOldOffsets.size() - 1);
+          }
         }
 
         if (finallytype == 2) { // astore
           seq.removeLast();
-          instrOldOffsets.remove(instrOldOffsets.size() - 1);
+          if (!instrOldOffsets.isEmpty()) {
+            instrOldOffsets.remove(instrOldOffsets.size() - 1);
+          }
         }
       }
     }


### PR DESCRIPTION
## Describe the bug

`FinallyProcessor.removeExceptionInstructionsEx` mutates two parallel structures on the same `BasicBlock`: `InstructionSequence seq` and `List<Integer> instrOldOffsets`. The two can drift apart when `verifyFinallyEx` re-invokes this method on the same handler block during multi-pass iteration — a previous pass shrank one list more than the other, then a later pass tries to remove from the now-empty offsets list and throws.

### Minimal repro

A Kotlin `bitmap.compress(...).use { ... }` try-finally (the standard \`CloseableKt.closeFinally\` pattern) consistently triggers it on R8-shrunk Android code.

### Stack trace

```
java.lang.IndexOutOfBoundsException: Index 0 out of bounds for length 0
  at java.base/java.util.ArrayList.remove(ArrayList.java:552)
  at org.jetbrains.java.decompiler.modules.decompiler.FinallyProcessor.removeExceptionInstructionsEx(FinallyProcessor.java:1058)
  at org.jetbrains.java.decompiler.modules.decompiler.FinallyProcessor.verifyFinallyEx(FinallyProcessor.java:573)
  at org.jetbrains.java.decompiler.modules.decompiler.FinallyProcessor.iterateGraph(FinallyProcessor.java:90)
```

## Describe the fix

`InstructionSequence.removeLast()` already self-guards (only removes if non-empty). I extended the same pattern to the four `instrOldOffsets.remove(...)` call sites and the two `seq.removeInstruction(0)` sites inside `removeExceptionInstructionsEx`. No behaviour change when the lists are in sync — only graceful no-op when they aren't.

This is a band-aid, not a root-cause fix: the underlying invariant violation (the two lists falling out of sync across re-invocations) is still worth investigating. But shipping the guard prevents loss of the entire method body for code that the rest of the pipeline could otherwise decompile correctly.

## Provenance disclosure

I diagnosed and authored this patch while pair-coding with Claude (Anthropic's coding agent) inside a focused diagnose-loop session against a real-world Android APK. I have personally read, understood, validated, and signed off on the change. Flagging this because of the AI-tools checkbox on the bugfix template — happy to discuss further or close and re-file as an issue.

## Checklist
- [x] This PR targets the latest `develop/` branch (`develop/1.13.0`).
- [ ] Unit tests were added or modified to validate this change. *(Existing test suite passes; happy to add a fixture if you'd like.)*
- [ ] No AI tools were used in making this change. *(See provenance disclosure above.)*