### PR TITLE
Kotlin: fall back to JVM supertypes for anonymous classes without Kotlin metadata

### DIFF
--- a/plugins/kotlin/src/main/java/org/vineflower/kotlin/KotlinWriter.java
+++ b/plugins/kotlin/src/main/java/org/vineflower/kotlin/KotlinWriter.java
@@ -738,28 +738,48 @@ public class KotlinWriter implements StatementWriter, Flags {
 
   private void writeClassDefinition(ClassNode node, TextBuffer buffer, int indent, KElement ktData, int kotlinFlags) {
     if (node.type == ClassNode.Type.ANONYMOUS) {
-      if (!(ktData instanceof KClass cls)) {
-        throw new IllegalStateException("Anonymous class does not have Class Kotlin metadata");
-      }
-
       buffer.append("object");
 
-      boolean first = true;
-      for (ProtoBuf.Type supertype : cls.proto().getSupertypeList()) {
-        KType kType = KType.from(supertype, cls.resolver());
-        if (VarType.VARTYPE_OBJECT.equals(kType)) {
-          // skip Any / Object supertype
-          continue;
-        }
+      if (ktData instanceof KClass cls) {
+        boolean first = true;
+        for (ProtoBuf.Type supertype : cls.proto().getSupertypeList()) {
+          KType kType = KType.from(supertype, cls.resolver());
+          if (VarType.VARTYPE_OBJECT.equals(kType)) {
+            // skip Any / Object supertype
+            continue;
+          }
 
-        if (first) {
-          buffer.append(" : ");
-          first = false;
-        } else {
-          buffer.append(", ");
-        }
+          if (first) {
+            buffer.append(" : ");
+            first = false;
+          } else {
+            buffer.append(", ");
+          }
 
-        buffer.append(kType.stringify(indent));
+          buffer.append(kType.stringify(indent));
+        }
+      } else {
+        // No Kotlin Class metadata (synthetic/lambda anonymous, R8-stripped, or
+        // failed metadata parse). Fall back to JVM superclass + interface list.
+        StructClass cl = node.classStruct;
+        boolean first = true;
+        if (cl.superClass != null) {
+          VarType superType = new VarType(cl.superClass.getString(), true);
+          if (!VarType.VARTYPE_OBJECT.equals(superType)) {
+            buffer.append(" : ").append(ExprProcessor.getCastTypeName(superType));
+            first = false;
+          }
+        }
+        for (String iface : cl.getInterfaceNames()) {
+          VarType ifaceType = new VarType(iface, true);
+          if (first) {
+            buffer.append(" : ");
+            first = false;
+          } else {
+            buffer.append(", ");
+          }
+          buffer.append(ExprProcessor.getCastTypeName(ifaceType));
+        }
       }
 
       return;


### PR DESCRIPTION
## Describe the bug

When `KotlinWriter` encounters a `ClassNode.Type.ANONYMOUS` whose `KElement` attribute is not a `KClass`, it throws `IllegalStateException(\"Anonymous class does not have Class Kotlin metadata\")` and the surrounding class's body is lost.

This is the dominant Kotlin-plugin failure on batch-mode decompilation of R8-shrunk Android apps. On a real ~3700-class app jar (Dartsmind 4.4.1 + 4.3.13), this single throw produced **302 distinct failing classes**, all from patterns the Kotlin team has already documented in #470 and the broader Kotlin work list at #262:

- Anonymous comparators from `sortedWith(compareByDescending { … })`
- Inlined suspending lambdas (\`crossinline\` into a suspending context — see #470's stack-trace migration from \`KFunction.parse:112\` (1.11.1) to \`KotlinWriter.writeClassDefinition:742\` (1.12.0))

The user's reported bisection finding for #470 — *\"the bug only triggers in batch mode; passing the outer class alone with the jar via `-e=...` works\"* — is consistent with this throw: in single-class mode, the lambda gets a `KFunction` attribute earlier in the call chain (line 292: `writeLambda(node, ...)`) so it never reaches `writeClassDefinition`. In batch mode, ordering or state differences leave some lambdas without that attribute, and the throw aborts them.

## Describe the fix

Rather than fix the upstream `KFunction`/`KClass` attribute attachment (which I don't have the full picture on without more time in `KotlinChooser.parseMetadataFor` and `KFunction.parse`), this PR makes `writeClassDefinition` graceful when no `KClass` metadata is present:

- The `KClass` branch is unchanged.
- The fallback branch emits `object : <super>, <iface1>, <iface2>` using the JVM `StructClass`'s superclass and interface list — the same information the Java-side writer uses for anonymous classes. `Object`/`Any` is filtered out as before.

### Measured impact on a real Android app

| metric | before | after |
| --- | --- | --- |
| Files with `\$VF: Couldn't be decompiled` (whole jar) | 593 | 455 |
| Of those, `IllegalStateException` from line 742 | 302 | 0 |
| Files in app's own package (com/zaglab) with any failure | 47 / 958 | 1 / 958 |

The remaining 455 jar-wide failures are all unrelated Java-core bugs (parsing failures, `FlattenStatementsHelper` NPEs, `IfHelper.collapseIfIf` NPE, etc.) — none in the Kotlin plugin's hot path.

### Caveats

- This is graceful **fallback**, not a metadata-attachment fix. The underlying \"why doesn't this class have `KClass` metadata?\" question remains open and is worth investigating separately — at minimum, the path in `KotlinChooser.parseMetadataFor` for k=3 synthetic classes where `KFunction.parse` `continue`s on unmatched suspend `<anonymous>` (line 113-117 of `KFunction.java`) leaves the class without an attribute and seems like a likely culprit.
- The fallback output won't recover Kotlin-style reified generics or other metadata-only info, but it does produce *something compilable* with the right supertype shape, which is a huge win over losing the entire enclosing class body.

## Related issues

- #470 — same root error site, also unresolved
- #262 — \"Big Kotlin Work List\" master tracker

## Provenance disclosure

I diagnosed and authored this patch while pair-coding with Claude (Anthropic's coding agent) inside a focused diagnose-loop session against a real-world Android APK. I have personally read, understood, validated, and signed off on the change. Flagging this because of the AI-tools checkbox on the bugfix template — happy to discuss further, rewrite/refactor in your preferred style, or close this and re-file as an issue with minimal repros if you'd rather not accept AI-assisted PRs at all.

## Checklist
- [x] This PR targets the latest `develop/` branch (`develop/1.13.0`).
- [ ] Unit tests were added or modified to validate this change. *(Existing Kotlin test suite passes including \`TestAnonymousEverything\`. Happy to write a new fixture that covers the metadata-absent path if you'd like.)*
- [ ] No AI tools were used in making this change. *(See provenance disclosure above.)*