### PR TITLE
ExprUtil: return null instead of throwing when constructor lookup fails

### DIFF
--- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ExprUtil.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ExprUtil.java
@@ -43,10 +43,15 @@ public final class ExprUtil {
       // own class
       MethodWrapper methodWrapper = wrapper.getMethodWrapper(CodeConstants.INIT_NAME, descriptor);
       if (methodWrapper == null) {
-        if (DecompilerContext.getOption(IFernflowerPreferences.IGNORE_INVALID_BYTECODE)) {
-          return null;
-        }
-        throw new RuntimeException("Constructor " + node.classStruct.qualifiedName + "." + CodeConstants.INIT_NAME + descriptor + " not found");
+        // Constructor not found. This happens legitimately when a caller has
+        // rewritten the descriptor — e.g. the Kotlin plugin strips the trailing
+        // `DefaultConstructorMarker` parameter from a default-args super call,
+        // so the resulting (ZI)V descriptor no longer matches any real
+        // (ZILDefaultConstructorMarker;)V constructor on the target. Downstream
+        // code (InvocationExprent.appendParamList et al.) already treats a null
+        // mask as "no synthetic parameters known"; returning null here recovers
+        // gracefully instead of aborting the entire enclosing class.
+        return null;
       }
       mask = methodWrapper.synthParameters;
     }


### PR DESCRIPTION
## Describe the bug

\`ExprUtil.getSyntheticParametersMask\` looks up a constructor by descriptor on the wrapper for the target class. If the lookup returns null it throws \`RuntimeException(\"Constructor X.<init>Y not found\")\` — the exception bubbles all the way up to \`Fernflower.getClassContent\`'s try/catch and aborts the **entire enclosing class** of the call site with a \`\$VF: Unable to decompile class\` stub.

### Real-world trigger (Kotlin plugin)

\`KConstructor.writePrimaryConstructor\` resugars a Kotlin default-args super call by stripping the trailing \`DefaultConstructorMarker\` parameter:

\`\`\`java
// org/vineflower/kotlin/struct/KConstructor.java:309
KUtils.removeArguments(invocation, DEFAULT_CONSTRUCTOR_MARKER);
buf.append(invocation.appendParamList(indent + 1));
\`\`\`

\`removeArguments\` mutates the invocation's \`stringDescriptor\` from \`(ZILkotlin/jvm/internal/DefaultConstructorMarker;)V\` to \`(ZI)V\`. The subsequent \`appendParamList\` call then runs:

\`\`\`java
// org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java:982
mask = ExprUtil.getSyntheticParametersMask(newNode, stringDescriptor, lstParameters.size());
\`\`\`

ExprUtil dutifully looks up \`<init>(ZI)V\` on the target class — and that constructor never existed; the target only has \`<init>()V\`, \`<init>(Z)V\`, and the synthetic \`<init>(ZILDefaultConstructorMarker;)V\`. The throw at line 49 then kills the whole enclosing class.

The bug is single-class-mode-invisible: in single-class mode the target class isn't in \`mapRootClasses\`, the early-out at line 35 (\`node != null ? ... : null\`) returns null without ever reaching the wrapper lookup, and decompilation succeeds. Only batch-mode runs reproduce the failure.

### Symptom

Real Android-app stack trace:

\`\`\`
java.lang.RuntimeException: Constructor com/zaglab/dartsmind/zlSupport/ZLEmptyNavFragment.<init>(ZI)V not found
  at org.jetbrains.java.decompiler.modules.decompiler.exps.ExprUtil.getSyntheticParametersMask(ExprUtil.java:49)
  at org.jetbrains.java.decompiler.modules.decompiler.exps.InvocationExprent.appendParamList(InvocationExprent.java:982)
\`\`\`

On the Dartsmind 4.4.1 APK (~14k classes), 19 of 958 \`com/zaglab/dartsmind/**\` Kotlin Fragment/View classes failed this way — every class that extended a Kotlin parent with default-args constructors. Including the top-level UI entry points: \`HomeFragment\`, \`SelectGameFragment\`, \`LocalPlayersFragment\`, \`ProfileSettingsFragment\`, \`PhotoEditFragment\`, etc.

## Describe the fix

Replace the throw with \`return null\`. Downstream callers already treat \`mask == null\` as a fully-supported \"no synthetic parameters known\" state:

\`\`\`java
// InvocationExprent.java:1118
if (mask == null || mask.get(x) == null) { ... }
\`\`\`

The existing \`IGNORE_INVALID_BYTECODE\` branch (line 46–48) already did exactly this for the same condition. The throw was overly defensive — it made the bug worse, not better.

### Measured impact

| | Before | After |
|---|---|---|
| Dartsmind 4.4.1: \`com/zaglab/\` class-level failures | 19 | **0** |
| Dartsmind 4.3.13: \`com/zaglab/\` class-level failures | 2 | **0** |
| Tree-wide class-level failures (4.4.1) | 65 | 32 |
| Existing test suite | passes | passes |

Trade-off at the call site: when this fallback fires, the \`DefaultConstructorMarker\` arg may now print verbatim instead of being suppressed by a known-good mask. That's strictly better than losing the entire class, and there's room for a follow-up improvement to detect-and-skip Kotlin default-args markers at print time even without a valid mask.

## Provenance disclosure

I diagnosed and authored this patch while pair-coding with Claude (Anthropic's coding agent) inside a focused diagnose-loop session against a real-world Android APK. I have personally read, understood, validated, and signed off on the change. Flagging this because of the AI-tools checkbox on the bugfix template — happy to discuss further or close and re-file as an issue.

## Checklist
- [x] This PR targets the latest \`develop/\` branch (\`develop/1.13.0\`).
- [ ] Unit tests were added or modified to validate this change. *(Existing suite passes; happy to add a fixture covering the Kotlin default-args ctor case if you'd like.)*
- [ ] No AI tools were used in making this change. *(See provenance disclosure above.)*