### PR TITLE
Kotlin: null-safe companion-name match in writeClass

### DIFF
--- a/plugins/kotlin/src/main/java/org/vineflower/kotlin/KotlinWriter.java
+++ b/plugins/kotlin/src/main/java/org/vineflower/kotlin/KotlinWriter.java
@@ -297,8 +297,10 @@ public class KotlinWriter implements StatementWriter, Flags {
       Optional<ClassNode> companion;
       if (ktData instanceof KClass cls && cls.proto().hasCompanionObjectName()) {
         String name = cls.resolver().resolve(cls.proto().getCompanionObjectName());
+        // Anonymous nested classes have a null simpleName; reverse the equals
+        // direction so the non-null companion name is the receiver.
         companion = node.nested.stream()
-          .filter(n -> n.simpleName.equals(name))
+          .filter(n -> name.equals(n.simpleName))
           .findAny();
       } else {
         companion = Optional.empty();


### PR DESCRIPTION
## Describe the bug

\`KotlinWriter.writeClass\` looks up a class's companion object among its nested ClassNodes:

\`\`\`java
// KotlinWriter.java:298-302
if (ktData instanceof KClass cls && cls.proto().hasCompanionObjectName()) {
  String name = cls.resolver().resolve(cls.proto().getCompanionObjectName());
  companion = node.nested.stream()
    .filter(n -> n.simpleName.equals(name))
    .findAny();
}
\`\`\`

Anonymous nested classes have \`simpleName == null\`. When the stream encounters one before the actual named companion, \`n.simpleName.equals(name)\` throws \`NullPointerException\`, which bubbles up to \`Fernflower.getClassContent\` and aborts the entire enclosing class with a \`\$VF: Unable to decompile class\` stub.

### Stack trace

\`\`\`
java.lang.NullPointerException: Cannot invoke \"String.equals(Object)\" because \"n.simpleName\" is null
  at org.vineflower.kotlin.KotlinWriter.lambda\$writeClass\$0(KotlinWriter.java:301)
\`\`\`

On the Dartsmind 4.3.13 APK: \`ChangeUsernameDialog.kt\` and \`ChangeEmailDialog.kt\` were both lost entirely. On the 4.4.1 build: 4 androidx/firebase classes (\`ComponentActivity\`, \`OkioStorage\`, \`FileStorage\`, \`FirebaseSessions\`).

## Describe the fix

Reverse the equals direction so the known non-null companion name is the receiver:

\`\`\`java
companion = node.nested.stream()
  .filter(n -> name.equals(n.simpleName))
  .findAny();
\`\`\`

Standard null-safe equals pattern; no behaviour change for nodes with a non-null simpleName.

### Verification

Existing test suite passes. Re-running both Dartsmind APKs end-to-end now produces zero \`com/zaglab/\` class-level failures.

## Provenance disclosure

I diagnosed and authored this patch while pair-coding with Claude (Anthropic's coding agent) inside a focused diagnose-loop session against a real-world Android APK. I have personally read, understood, validated, and signed off on the change. Flagging this because of the AI-tools checkbox on the bugfix template — happy to discuss further or close and re-file as an issue.

## Checklist
- [x] This PR targets the latest \`develop/\` branch (\`develop/1.13.0\`).
- [ ] Unit tests were added or modified to validate this change. *(Existing suite passes; the fix is a one-line null-safety patch — happy to add a fixture if you'd like a regression-specific test.)*
- [ ] No AI tools were used in making this change. *(See provenance disclosure above.)*