### PR TITLE
Fix ClassesProcessor not whitelisting class files

### DIFF
--- a/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java
+++ b/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java
@@ -82,7 +82,7 @@ public class ClassesProcessor implements CodeConstants {
       return true;
 
     for (String prefix : this.whitelist) {
-      if (cls.startsWith(prefix))
+      if (cls.startsWith(prefix) || prefix.startsWith(cls))
         return true;
     }
 


### PR DESCRIPTION
Fixes #593!

This PR branch should probably be tested on the CLI against some other projects, because I am not sure if adding this second check will influence anything.

### An explanation about the bug

When using `--only=com/example`, the `com/example` is marked as a whitelisted prefix; thus any directories in a JAR being matched against these whitelist prefixes will be created. However, when matching a singular class file (e.g. `--only=com/example/MyClass`), the original check against the to-be-created directory `com/example` would fail.

The check will boil down to:
```java
"com/example".startsWith("com/example/MyClass")
```
and it is obvious that this would fail, thus the directory would not be created, and after decompilation happens and the class file is being dumped to a file, it will fail because of the parent directories not existing.

It took me a few hours to find a fix that didn't feel hacky, though I will admit that this still feels a little hacky and might have some unknown-to-me consequences. This simple change will affect this whitelist check and makes the check:
```java
"com/example".startsWith("com/example/MainClass") || "com/example/MainClass".startsWith("com/example")
```
This check satisfies the directory-creating code and will create the directories just fine. Yippee!