### PR TITLE
Fix non-ambiguous varargs overload being marked as ambiguous

### DIFF
--- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
@@ -1395,7 +1395,7 @@ public class InvocationExprent extends Exprent {
           }
 
           // If we have two types which are both Object, it's hard to tell what is compatible.
-          // We need to get the common type between the two. If there isn't, it means the type isn't compatible.
+          // We need to get the common type between the two. If there isn't one, it means the type isn't compatible.
           if (leftType.type == CodeType.OBJECT && rightType.type == CodeType.OBJECT) {
             VarType commonType = VarType.meet(leftType, rightType);
             if (commonType == null || commonType == VarType.VARTYPE_NULL) {

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
@@ -1393,6 +1393,15 @@ public class InvocationExprent extends Exprent {
           if (leftType.arrayDim != rightType.arrayDim) {
             return false;
           }
+
+          // If we have two types which are both Object, it's hard to tell what is compatibe.
+          // We need to get the common type between the two. If there isn't, it means the type isn't compatible.
+          if (leftType.type == CodeType.OBJECT && rightType.type == CodeType.OBJECT) {
+            VarType commonType = VarType.meet(leftType, rightType);
+            if (commonType == null || commonType == VarType.VARTYPE_NULL) {
+              return false;
+            }
+          }
         }
       }
       return true;

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
@@ -1394,7 +1394,7 @@ public class InvocationExprent extends Exprent {
             return false;
           }
 
-          // If we have two types which are both Object, it's hard to tell what is compatibe.
+          // If we have two types which are both Object, it's hard to tell what is compatible.
           // We need to get the common type between the two. If there isn't, it means the type isn't compatible.
           if (leftType.type == CodeType.OBJECT && rightType.type == CodeType.OBJECT) {
             VarType commonType = VarType.meet(leftType, rightType);

--- a/testData/results/pkg/TestArrayArg.dec
+++ b/testData/results/pkg/TestArrayArg.dec
@@ -72,37 +72,61 @@ public class TestArrayArg {
       overloaded3(null, "s");// 72
    }// 73
 
-   private static void overloaded(Object o) {
-      System.out.println("non-variadic");// 76
+   public static void test7() {
+      overloaded4(new String[]{"arg"});// 76
    }// 77
 
-   private static void overloaded(Object... o) {
-      System.out.println("variadic");// 80
+   public static void test7_() {
+      overloaded4("arg");// 80
    }// 81
 
-   private static void overloaded1(String s) {
-      System.out.println("non-variadic");// 84
+   public static void test7b() {
+      overloaded4(7);// 84
    }// 85
 
-   private static void overloaded1(String... s) {
-      System.out.println("variadic");// 88
+   private static void overloaded(Object o) {
+      System.out.println("non-variadic");// 88
    }// 89
 
-   private static void overloaded2(Object o) {
-      System.out.println("non-array");// 92
+   private static void overloaded(Object... o) {
+      System.out.println("variadic");// 92
    }// 93
 
-   private static void overloaded2(Object[] o) {
-      System.out.println("array");// 96
+   private static void overloaded1(String s) {
+      System.out.println("non-variadic");// 96
    }// 97
 
-   private static void overloaded3(Object o, Number n) {
-      System.out.println("non-array");// 100
+   private static void overloaded1(String... s) {
+      System.out.println("variadic");// 100
    }// 101
 
-   private static void overloaded3(String s, String s2) {
+   private static void overloaded2(Object o) {
       System.out.println("non-array");// 104
    }// 105
+
+   private static void overloaded2(Object[] o) {
+      System.out.println("array");// 108
+   }// 109
+
+   private static void overloaded3(Object o, Number n) {
+      System.out.println("non-array");// 112
+   }// 113
+
+   private static void overloaded3(String s, String s2) {
+      System.out.println("non-array");// 116
+   }// 117
+
+   private static void overloaded4(String s) {
+      System.out.println("non-variadic");// 120
+   }// 121
+
+   private static void overloaded4(String... s) {
+      System.out.println("variadic");// 124
+   }// 125
+
+   private static void overloaded4(Integer... i) {
+      System.out.println("variadic-other-type");// 128
+   }// 129
 }
 
 class 'pkg/TestArrayArg' {
@@ -274,43 +298,37 @@ class 'pkg/TestArrayArg' {
       6      72
    }
 
-   method 'overloaded (Ljava/lang/Object;)V' {
-      0      75
-      1      75
-      2      75
-      3      75
-      4      75
-      5      75
+   method 'test7 ()V' {
       6      75
       7      75
-      8      76
+      9      75
+      a      75
+      b      75
+      c      76
    }
 
-   method 'overloaded ([Ljava/lang/Object;)V' {
+   method 'test7_ ()V' {
       0      79
       1      79
       2      79
       3      79
       4      79
-      5      79
-      6      79
-      7      79
-      8      80
+      5      80
    }
 
-   method 'overloaded1 (Ljava/lang/String;)V' {
-      0      83
-      1      83
-      2      83
-      3      83
-      4      83
-      5      83
+   method 'test7b ()V' {
       6      83
       7      83
-      8      84
+      8      83
+      9      83
+      a      83
+      c      83
+      d      83
+      e      83
+      f      84
    }
 
-   method 'overloaded1 ([Ljava/lang/String;)V' {
+   method 'overloaded (Ljava/lang/Object;)V' {
       0      87
       1      87
       2      87
@@ -322,7 +340,7 @@ class 'pkg/TestArrayArg' {
       8      88
    }
 
-   method 'overloaded2 (Ljava/lang/Object;)V' {
+   method 'overloaded ([Ljava/lang/Object;)V' {
       0      91
       1      91
       2      91
@@ -334,7 +352,7 @@ class 'pkg/TestArrayArg' {
       8      92
    }
 
-   method 'overloaded2 ([Ljava/lang/Object;)V' {
+   method 'overloaded1 (Ljava/lang/String;)V' {
       0      95
       1      95
       2      95
@@ -346,7 +364,7 @@ class 'pkg/TestArrayArg' {
       8      96
    }
 
-   method 'overloaded3 (Ljava/lang/Object;Ljava/lang/Number;)V' {
+   method 'overloaded1 ([Ljava/lang/String;)V' {
       0      99
       1      99
       2      99
@@ -358,7 +376,7 @@ class 'pkg/TestArrayArg' {
       8      100
    }
 
-   method 'overloaded3 (Ljava/lang/String;Ljava/lang/String;)V' {
+   method 'overloaded2 (Ljava/lang/Object;)V' {
       0      103
       1      103
       2      103
@@ -368,6 +386,78 @@ class 'pkg/TestArrayArg' {
       6      103
       7      103
       8      104
+   }
+
+   method 'overloaded2 ([Ljava/lang/Object;)V' {
+      0      107
+      1      107
+      2      107
+      3      107
+      4      107
+      5      107
+      6      107
+      7      107
+      8      108
+   }
+
+   method 'overloaded3 (Ljava/lang/Object;Ljava/lang/Number;)V' {
+      0      111
+      1      111
+      2      111
+      3      111
+      4      111
+      5      111
+      6      111
+      7      111
+      8      112
+   }
+
+   method 'overloaded3 (Ljava/lang/String;Ljava/lang/String;)V' {
+      0      115
+      1      115
+      2      115
+      3      115
+      4      115
+      5      115
+      6      115
+      7      115
+      8      116
+   }
+
+   method 'overloaded4 (Ljava/lang/String;)V' {
+      0      119
+      1      119
+      2      119
+      3      119
+      4      119
+      5      119
+      6      119
+      7      119
+      8      120
+   }
+
+   method 'overloaded4 ([Ljava/lang/String;)V' {
+      0      123
+      1      123
+      2      123
+      3      123
+      4      123
+      5      123
+      6      123
+      7      123
+      8      124
+   }
+
+   method 'overloaded4 ([Ljava/lang/Integer;)V' {
+      0      127
+      1      127
+      2      127
+      3      127
+      4      127
+      5      127
+      6      127
+      7      127
+      8      128
    }
 }
 
@@ -423,3 +513,15 @@ Lines mapping:
 101 <-> 101
 104 <-> 104
 105 <-> 105
+108 <-> 108
+109 <-> 109
+112 <-> 112
+113 <-> 113
+116 <-> 116
+117 <-> 117
+120 <-> 120
+121 <-> 121
+124 <-> 124
+125 <-> 125
+128 <-> 128
+129 <-> 129

--- a/testData/src/java8/pkg/TestArrayArg.java
+++ b/testData/src/java8/pkg/TestArrayArg.java
@@ -72,6 +72,18 @@ public class TestArrayArg {
     overloaded3(null, "s");
   }
 
+  public static void test7() {
+    overloaded4(new String[]{"arg"});
+  }
+
+  public static void test7_() {
+    overloaded4("arg");
+  }
+
+  public static void test7b() {
+    overloaded4(7);
+  }
+
   private static void overloaded(Object o) {
     System.out.println("non-variadic");
   }
@@ -102,5 +114,17 @@ public class TestArrayArg {
 
   private static void overloaded3(String s, String s2) {
     System.out.println("non-array");
+  }
+
+  private static void overloaded4(String s) {
+    System.out.println("non-variadic");
+  }
+
+  private static void overloaded4(String... s) {
+    System.out.println("variadic");
+  }
+
+  private static void overloaded4(Integer... i) {
+    System.out.println("variadic-other-type");
   }
 }


### PR DESCRIPTION
Fixes #584!

I'm not sure if this is the right way to go about it since I know nothing about the area that this code lives. From what I've seen, the issue is that when it is checking a vararg type is ambiguous, it will match even when the type left type and right type are Object.

The main point is to check if the type can be boxed implicitly, but this probably isn't the cleanest way (if you know better, please comment or suggest!).

I've added a test case to show this, but I'll explain it here. In the example shown in the issue, there are overloads for `String`, `String...`, and `Integer...`. When the code is checking for ambiguous vararg overload types, and given `overload(123);`, it will incorrectly match both `String...` and `Integer...` as types because they are both `Object`; thus it becomes ambiguous even though it isn't exactly.

Uhh thats really all of it, simple change. All i did was when checking that the types are matching, I also checked the intersect/meet point between the types. if they don't share a common type anywhere at all then it's probably some completely different type and it shouldn't even be considered!