### PR TITLE
Fix merged variable keeping its narrower declared type

### DIFF
--- a/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarDefinitionHelper.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarDefinitionHelper.java
@@ -1041,6 +1041,15 @@ public class VarDefinitionHelper {
       else if (expr instanceof VarExprent) {
         VarExprent var = (VarExprent)expr;
         VarVersionPair old = new VarVersionPair(var);
+        if (old.equals(to) && var.isDefinition()) {
+          // Refresh the merge target's declared type when its declaration is stored inline,
+          // so it matches the widened type of the merged writes (Vineflower#578).
+          VarType merged = getMergedType(from, to);
+          if (merged != null) {
+            var.setVarType(merged);
+          }
+          continue;
+        }
         if (!old.equals(from)) {
           continue;
         }

--- a/test/org/jetbrains/java/decompiler/SingleClassesTest.java
+++ b/test/org/jetbrains/java/decompiler/SingleClassesTest.java
@@ -863,6 +863,7 @@ public class SingleClassesTest extends SingleClassesTestBase {
     register(JAVA_25, "/TestCompactSourceFileOtherMembers");
     register(JAVA_25, "/TestCompactSourceFileOtherMembersStatic");
     register(JAVA_8_NODEBUG, "TestByteArrayMerge");
+    register(JAVA_8_NODEBUG, "TestByteVarIntMerge");
     register(JAVA_8, "TestFloatDupStoreTernary");
   }
 

--- a/testData/results/pkg/TestByteVarIntMerge.dec
+++ b/testData/results/pkg/TestByteVarIntMerge.dec
@@ -1,0 +1,85 @@
+package pkg;
+
+public class TestByteVarIntMerge {
+   static byte[] bytes = new byte[4];
+
+   public static int test(int[] var0) {
+      int var1;
+      if (var0[0] < bytes.length) {
+         var1 = bytes[var0[0]];
+      } else {
+         var1 = 15;
+      }
+
+      switch ((byte)var1) {
+         case 2:
+            var1 = var0[0];
+            return var1 + 6;
+         default:
+            return 0;
+      }
+   }
+}
+
+class 'pkg/TestByteVarIntMerge' {
+   method '<clinit> ()V' {
+      0      3
+   }
+
+   method 'test ([I)I' {
+      0      7
+      1      7
+      2      7
+      3      7
+      4      7
+      5      7
+      6      7
+      7      7
+      8      7
+      9      7
+      a      8
+      b      8
+      c      8
+      d      8
+      e      8
+      f      8
+      10      8
+      11      8
+      15      10
+      16      10
+      17      10
+      18      13
+      19      13
+      1a      13
+      1b      13
+      1c      13
+      1d      13
+      1e      13
+      1f      13
+      20      13
+      21      13
+      22      13
+      23      13
+      24      13
+      25      13
+      26      13
+      27      13
+      28      13
+      29      13
+      2a      13
+      2b      13
+      2c      15
+      2d      15
+      2e      15
+      2f      15
+      30      16
+      31      16
+      32      16
+      33      16
+      34      16
+      35      18
+      36      18
+   }
+}
+
+Lines mapping:

--- a/testData/results/pkg/TestSwitchExpressionAssignmentOrder.dec
+++ b/testData/results/pkg/TestSwitchExpressionAssignmentOrder.dec
@@ -3,7 +3,7 @@ package pkg;
 public class TestSwitchExpressionAssignmentOrder {
    public int test1(int i1) {
       int v = 5;// 5
-      byte var3;
+      int var3;
 
       return v + (var3 = this.test1(i1)) + switch (var3) {// 6
          case 0 -> 1;// 7
@@ -42,7 +42,7 @@ public class TestSwitchExpressionAssignmentOrder {
 
    public int test4(int i1) {
       int v = 5;// 36
-      byte var4;
+      int var4;
       int o = var4;
 
       return (var4 = i1 + v) + var4 + switch (v = v + var4) {// 37

--- a/testData/src/java8nodebug/pkg/TestByteVarIntMerge.java
+++ b/testData/src/java8nodebug/pkg/TestByteVarIntMerge.java
@@ -1,0 +1,22 @@
+package pkg;
+
+public class TestByteVarIntMerge {
+  static byte[] bytes = new byte[4];
+
+  public static int test(int[] box) {
+    int value;
+    if (box[0] < bytes.length) {
+      value = bytes[box[0]];
+    } else {
+      value = 15;
+    }
+
+    switch ((byte)value) {
+      case 2:
+        value = box[0];
+        return value + 6;
+      default:
+        return 0;
+    }
+  }
+}


### PR DESCRIPTION
Fixes #578.

A variable that is a byte on one path and reused as an int on another was declared as a byte, so the decompiled code did not compile. Assigning an int to a byte needs a narrowing cast (JLS 5.1.3).

When two variable versions are merged, `remapVar` retypes the writes and the type map to the wider type, but it only refreshed the declared type for declarations kept in a statement's var definitions list. When the merge target's declaration is stored inline as a definition exprent, it kept its old, narrower type. This adds the missing refresh for that case.

### Testing
Added `TestByteVarIntMerge` (java8nodebug), which declares the variable as a byte before the fix and an int after.

This also updates the expected output of `TestSwitchExpressionAssignmentOrder`. Its committed result already had the same problem baked in (`byte var3` assigned an int, `byte var4` assigned int arithmetic) and did not compile; both now decompile as int. A separate assignment order issue in that test's `test4` is pre existing and left untouched.

The full test suite passes.
