### PR TITLE
Fix duplicated field reads stored in locals

### DIFF
--- a/src/org/jetbrains/java/decompiler/modules/decompiler/StackVarsProcessor.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/StackVarsProcessor.java
@@ -18,6 +18,7 @@ import org.jetbrains.java.decompiler.modules.decompiler.stats.CatchStatement;
 import org.jetbrains.java.decompiler.modules.decompiler.stats.DoStatement;
 import org.jetbrains.java.decompiler.modules.decompiler.stats.RootStatement;
 import org.jetbrains.java.decompiler.modules.decompiler.stats.Statement;
+import org.jetbrains.java.decompiler.modules.decompiler.stats.SynchronizedStatement;
 import org.jetbrains.java.decompiler.modules.decompiler.vars.VarVersionNode;
 import org.jetbrains.java.decompiler.modules.decompiler.vars.VarVersionPair;
 import org.jetbrains.java.decompiler.modules.decompiler.vars.VarVersionsGraph;
@@ -441,6 +442,16 @@ public class StackVarsProcessor {
     // stack variables only
     if ((!left.isStack() && !options.inlineRegularVars) &&
         (!(right instanceof VarExprent variable) || !variable.isCatchTempVar())) { // special case catch(... ex)
+      setRet(ret, -1, changed);
+      return;
+    }
+
+    // A dup followed by a store can make one field-read stack value feed both a local and another
+    // expression. Inlining the field into the other expression would evaluate it a second time.
+    if (right instanceof FieldExprent &&
+        !(stat instanceof SynchronizedStatement) &&
+        usedVers.size() > 1 &&
+        isAssignedToRegularVariable(usedVers, ssau)) {
       setRet(ret, -1, changed);
       return;
     }
@@ -941,6 +952,38 @@ public class StackVarsProcessor {
     setNotDoms.removeAll(setVisited);
 
     return !setNotDoms.isEmpty();
+  }
+
+  private static boolean isAssignedToRegularVariable(List<VarVersionNode> usedVersions, SSAUConstructorSparseEx ssau) {
+    Deque<VarVersionPair> stack = usedVersions.stream()
+      .map(VarVersionNode::asPair)
+      .collect(Collectors.toCollection(ArrayDeque::new));
+    Set<VarVersionPair> visited = new HashSet<>();
+
+    while (!stack.isEmpty()) {
+      VarVersionPair use = stack.removeFirst();
+      if (!visited.add(use)) {
+        continue;
+      }
+
+      for (Entry<VarVersionPair, VarVersionPair> assignment : ssau.getVarAssignmentMap().entrySet()) {
+        if (!use.equals(assignment.getValue())) {
+          continue;
+        }
+
+        VarVersionPair target = assignment.getKey();
+        if (target.var >= 0 && target.var < VarExprent.STACK_BASE) {
+          return true;
+        }
+
+        VarVersionNode targetNode = ssau.getSsuVersions().nodes.getWithKey(target);
+        if (targetNode != null) {
+          targetNode.successors.stream().map(VarVersionNode::asPair).forEach(stack::addLast);
+        }
+      }
+    }
+
+    return false;
   }
 
   private static boolean isVersionToBeReplaced(VarVersionPair usedvar,

--- a/test/org/jetbrains/java/decompiler/SingleClassesTest.java
+++ b/test/org/jetbrains/java/decompiler/SingleClassesTest.java
@@ -284,6 +284,7 @@ public class SingleClassesTest extends SingleClassesTestBase {
     register(KOTLIN, "TestSynchronizedUnprotected");
     register(JAVA_8, "TestInterfaceSuper");
     register(JASM, "TestFieldSingleAccess");
+    register(JAVA_8, "TestDuplicatedFieldRead");
     register(JAVA_8, "package-info");
 
     register(JAVA_8, "TestInner2");

--- a/testData/results/pkg/TestDuplicatedFieldRead.dec
+++ b/testData/results/pkg/TestDuplicatedFieldRead.dec
@@ -1,0 +1,43 @@
+package pkg;
+
+public class TestDuplicatedFieldRead {
+   private static volatile int staticField;
+   private int instanceField;
+
+   public static int readStaticOnce() {
+      int value;
+      return (value = staticField) * value;// 9
+   }
+
+   public int readInstanceOnce() {
+      int value;
+      return (value = this.instanceField) * value;// 14
+   }
+}
+
+class 'pkg/TestDuplicatedFieldRead' {
+   method 'readStaticOnce ()I' {
+      0      8
+      1      8
+      2      8
+      4      8
+      5      8
+      6      8
+      7      8
+   }
+
+   method 'readInstanceOnce ()I' {
+      0      13
+      1      13
+      2      13
+      3      13
+      5      13
+      6      13
+      7      13
+      8      13
+   }
+}
+
+Lines mapping:
+9 <-> 9
+14 <-> 14

--- a/testData/src/java8/pkg/TestDuplicatedFieldRead.java
+++ b/testData/src/java8/pkg/TestDuplicatedFieldRead.java
@@ -1,0 +1,16 @@
+package pkg;
+
+public class TestDuplicatedFieldRead {
+  private static volatile int staticField;
+  private int instanceField;
+
+  public static int readStaticOnce() {
+    int value;
+    return (value = staticField) * value;
+  }
+
+  public int readInstanceOnce() {
+    int value;
+    return (value = instanceField) * value;
+  }
+}


### PR DESCRIPTION
## Describe the bug
A field read duplicated on the operand stack and stored in a local could be inlined into another expression, causing the decompiled code to evaluate the field twice. This changes semantics for volatile or otherwise mutable fields.

## Describe the fix
Prevent field-expression inlining when the SSA value has multiple uses and flows into a regular local variable, while preserving synchronized-statement handling. Add regression coverage for both static and instance field reads.

## Testing
- `./gradlew.bat :test --tests org.jetbrains.java.decompiler.SingleClassesTest --no-daemon` (JDK 17)

## Checklist
- [x] This PR targets the latest `develop/` branch.
- [x] Unit tests were added or modified to validate this change.
- [x] No AI tools were used in making this change.

Fixes #607